### PR TITLE
Bapp 1108 removed all old header description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ End users having one or more NetCentric BankIDs may use BankID App as an HA2 mec
 
 Controlling OTP mechanisms is the bank's RA responsibility. Vipps does not access the BankID ODS system.
 
-If the bank open it's RA for calls from Vipps, then end users may activate and connect BankID APP 
+If the bank opens it's RA for calls from Vipps, then end users may activate and connect BankID APP 
 to their Netcentric BankID with no manual interaction from the bank. 
 
 ### Vipps using RA
@@ -15,7 +15,7 @@ Activating the BankID APP requires that the end user authenticates using BankID 
 will call the BankID issuing RA to enable BankID App as an additional OTP mechanism.
 
 The RA may implement different degrees of functionality  
-* _OTP Administration_ which is the basic operations used by Vipps to to enable or disable BankID App as an OTP mechanism.
+* _OTP Administration_ which is the basic operations used by Vipps to enable or disable BankID App as an OTP mechanism.
 * _Activation without Code Device_ which enables usecases where the end user does not have another code device.   
 
 Supporting the basic _OTP administration_ SPI is sufficient to add BankID App to end users already having a Netcentric BankID.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # BankID app integration
 This guide describes how to integrate the BankID App as an HA2 mechanism for a BankID issuing bank.
 
-The bank needs to open it's BankID RA for calls from Vipps, so that Vipps can connect the BankID App with a BankID.
+To enable BankID App the bank's BankID RA system must handle at least the first of these requirements 
+* Enable and disable the OTP service _bapp_ manually 
+* Enable and disable OTP service _bapp_ automatically by calls from Vipps
+* Hold verified end user contact information and send messages to user by SMS and email or post as a response to calls from Vipss. 
+
+The bank needs to open it's RA for calls from Vipps to integrate BankID APP such that end users may activate BankID APP themselves
+with no manual interaction from the bank.
+ 
+Support for the basic OTP administration operations is sufficient to add BankID App to end users already having a Netcentric BankID. 
   
 For information about API keys, product activation, etc see [Getting Started](https://github.com/vippsas/bankid-app-api/blob/master/bankid-app-getting-started.md).
 
 For API documentation and development guidelines please see our [BankID app API guide](https://github.com/vippsas/bankid-app-api/blob/master/bankid-app-api.md).
 
-You can peruse the API reference documentation as [Swagger](https://vippsas.github.io/bankid-app-api/) or [ReDoc](https://vippsas.github.io/bankid-app-api/redoc.html).
+You can peruse the SPI reference documentation as [Swagger](https://vippsas.github.io/bankid-app-api/) or [ReDoc](https://vippsas.github.io/bankid-app-api/redoc.html).
 
 Building this documentation, run 
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,33 @@
 # BankID app integration
 This guide describes how to integrate the BankID App as an HA2 mechanism for a BankID issuing bank.
 
-To enable BankID App the bank's BankID RA system must handle at least the first of these requirements 
-* Enable and disable the OTP service _bapp_ manually 
-* Enable and disable OTP service _bapp_ automatically by calls from Vipps
-* Hold verified end user contact information and send messages to user by SMS and email or post as a response to calls from Vipss. 
+### Preconditions
+End users having one or more NetCentric BankIDs may use BankID App as an HA2 mechanism.
 
-The bank needs to open it's RA for calls from Vipps to integrate BankID APP such that end users may activate BankID APP themselves
-with no manual interaction from the bank.
- 
-Support for the basic OTP administration operations is sufficient to add BankID App to end users already having a Netcentric BankID. 
+Controlling OTP mechanisms is the bank's RA responsibility. Vipps does not access the BankID ODS system.
+
+If the bank open it's RA for calls from Vipps, then end users may activate and connect BankID APP 
+to their Netcentric BankID with no manual interaction from the bank. 
+
+### Vipps using RA
+
+Activating the BankID APP requires that the end user authenticates using BankID or BankID on Mobile, then Vipps 
+will call the BankID issuing RA to enable BankID App as an additional OTP mechanism.
+
+The RA may implement different degrees of functionality  
+* _OTP Administration_ which is the basic operations used by Vipps to to enable or disable BankID App as an OTP mechanism.
+* _Activation without Code Device_ which enables usecases where the end user does not have another code device.   
+
+Supporting the basic _OTP administration_ SPI is sufficient to add BankID App to end users already having a Netcentric BankID.
+
+Supporting the _Activation without Code Device_ SPI will in addition make it possible for Vipps to enable BankID App 
+in usecases where the end user does not have a way to authenticate, for example no other code device.
+
+### RA using Vipps 
+
+Vipps offers an API to inspect and modify the bank's end users BankID App relation.     
+  
+### Links
   
 For information about API keys, product activation, etc see [Getting Started](https://github.com/vippsas/bankid-app-api/blob/master/bankid-app-getting-started.md).
 

--- a/bankid-app-api.md
+++ b/bankid-app-api.md
@@ -3,9 +3,10 @@
 The BankID app is an HA2-mechanism (OTP) in the BankID infrastructure. The name of this HA2-mechanism is _bapp_.
 The RA-system of the bank issuing the enduser's BankID must support the _bapp_ HA2-mechanism. 
 
-When an enduser downloads and activates the BankID app, Vipps will, if automatic integration is set up, send 
-one or more requests to the enduser's BankID issuing bank to add the _bapp_ HA2 mechanism to the BankID. Please see the 
-BankID Core (COI) documentation for more information regarding the BankID HA2 mechanism.
+When an enduser downloads and activates the BankID app, Vipps will send one or more requests to the end user's 
+BankID issuing RA to add the _bapp_ HA2 mechanism to the end user's NetCentric BankID. 
+RA should then issue an OTPAdd against BankID ODS. 
+Please see the BankID Core (COI) documentation for more information regarding the BankID HA2 mechanism.
 
 ## BankID app API endpoints offered by Vipps
 Vipps offers an administration API allowing the bank issuing BankIDs to query if an end user has activated BankID app, and to enable/disable the app for a given end user.

--- a/bankid-app-api.md
+++ b/bankid-app-api.md
@@ -3,70 +3,40 @@
 The BankID app is an HA2-mechanism (OTP) in the BankID infrastructure. The name of this HA2-mechanism is _bapp_.
 The RA-system of the bank issuing the enduser's BankID must support the _bapp_ HA2-mechanism. 
 
-When an enduser downloads and activates the BankID app, Vipps will send 
-a request to the enduser's BankID issuing bank to add the _bapp_ HA2 mechanism to the BankID. Please see the 
+When an enduser downloads and activates the BankID app, Vipps will, if automatic integration is set up, send 
+one or more requests to the enduser's BankID issuing bank to add the _bapp_ HA2 mechanism to the BankID. Please see the 
 BankID Core (COI) documentation for more information regarding the BankID HA2 mechanism.
 
 ## BankID app API endpoints offered by Vipps
-Vipps offers an administration API allowing the bank issuing BankIDs to query if an enduser has activated BankID app, and to enable/disable the app for a given enduser.
+Vipps offers an administration API allowing the bank issuing BankIDs to query if an end user has activated BankID app, and to enable/disable the app for a given end user.
 Security is provided by OpenID connect (OIDC) access tokens, issued by BankID OIDC.
 
 [comment]: # (TODO: should be described)
 
-## BankID RA API endpoints required by Vipps
-In order for Vipps to request BankID app to be added as an HA2-mechanism to an enduser's BankID, the bank must implement the API 
+## BankID RA SPI endpoints required by Vipps
+In order for Vipps to request BankID app to be added as an HA2-mechanism to an enduser's BankID, the bank must implement the SPI 
 described here. 
 
 ### Security measures
 The endpoints must be secured using signed HTTP messages according to the 
 [Signing HTTP Messages](https://tools.ietf.org/html/draft-cavage-http-signatures-12) protocol. The requests sent by Vipps contains 
-a Signature header as described in this protocol. The signature algorithm used is rsa-sha256. All the request headers listed below 
-are included in the signature. The receiver must verify the signature using the certificate received 
+a Signature header as described in this protocol. The signature algorithm used is rsa-sha256. 
+The receiver must verify the signature using the certificate received 
 from Vipps as described in [Getting Started](https://github.com/vippsas/bankid-app-api/blob/master/bankid-app-getting-started.md). 
 
-Note that the protocol defines two ways of sending the Signature, either in the _Authorization_ header or as a headervalue named _Signature_. 
+Implementation notes:
+* The protocol defines two ways of sending the Signature, either in the _Authorization_ header or as a headervalue named _Signature_. 
 Vipps uses the header _Signature_ variant.
+* For source code generation based on this SPI the .json file seems less errorprone. The locale constant _no_ is 
+translated into _FALSE_ when using the .yaml file and that causes errors. 
+* [HTTP signature implementations](https://github.com/w3c-ccg/http-signatures/issues/1) offers a list of implementations for the protocol.
+* The maven plugin _io.swagger.codegen.v3:swagger-codegen-maven-plugin:3.0.19_ may be used for code generation
 
 ### Request endpoints
 
-| Service | Verb | Response Schema: application/json | Description |
-| ----------- | ----------- | ----------- | ----------- |
-| Status of BankID app | `GET` | status: ENABLED / NOT_ENABLED / NOT_AVAILABLE / BANK_ID_NOT_AVAILABLE / BLOCKED_BY_BANK / BLOCKED_IN_ODS |  Request the status of the _bapp_ HA2 service of the BankID of the given user |
-| Add BankID app | `PUT` | status: ENABLED / NOT_ENABLED / ALREADY_ENABLED / NOT_AVAILABLE / BANK_ID_NOT_AVAILABLE / BLOCKED_BY_BANK / BLOCKED_IN_ODS | Request the _bapp_ HA2 service to be added to the BankID of the given user |
-| Delete BankID app | `DELETE` | status: DELETED / NOT_ENABLED / BLOCKED_IN_ODS | Request the _bapp_ HA2 service to be removed from the BankID of the given user |
+Detailed description of the request endpoints are found in the SPI reference documentation as [Swagger](https://vippsas.github.io/bankid-app-api/) or [ReDoc](https://vippsas.github.io/bankid-app-api/redoc.html).
 
-The requests sent by Vipps requires the following headers. None of the requests have a body. 
-
-| Header | Description | Example value |
-| ----------- | ----------- | ----------- |
-| Signature | The signature produced with Vipps private key | _keyId="fa998090",algorithm="rsa-sha256",headers="(request-target) date x-client-clientname x-dataownerorgid x-client-requestid x-customerid",signature="o7zK892...."_ |
-| (request-target) | Standard Http signature protocol header | _/api/enduser/bankid/netcentric/otp/bapp_
-| Date | Standard http date header, GMT and english locale | _Mon, 16 Sep 2019 12:12:21 GMT_ |
-| X-CLIENT-CLIENTNAME | The BankID app client name | always _vipps-bapp-client_ |
-| X-DATAOWNERORGID | BankID originator ID | _2811_ |
-| X-CLIENT-REQUESTID | Unique identifier of the request (e.g. used as log reference) | _90921bc0-3550-47ec-ada5-f79ae86bad95_ |
-| X-CUSTOMERID | Norwegian National identity number | _11111111016_ |
-
-**Successful responses** should be returned with HTTP status code 200 and contain a JSON body with a _status_ value. 
-Response example:  
-`{
-  "status": "BANK_ID_NOT_AVAILABLE"    
-}`
-The meaning of the following statuses are:
- 
-| Status | Description |
-| ----------- | ----------- |
-| ENABLED | OTP BankID app is enabled for the enduser |
-| NOT_ENABLED | OTP BankID app is not enabled, but could be |
-| ALREADY_ENABLED | OTP BankID app was already enabled |
-| NOT_AVAILABLE | OTP BankID app is not available for the bank |
-| BANK_ID_NOT_AVAILABLE | Enduser doesn't have an active Netcentric BankID |
-| BLOCKED_BY_BANK | Enduser is not allowed to use OTP BankID app |
-| BLOCKED_IN_ODS | OTP BankID app is connected to the BankID, but was blocked by ODS because of too many failed attempts |
-| DELETED | OTP BankID app was successfully deleted | 
-
-**Error responses** from Ra should be returned with HTTP status code 401. An non-200 status will stop BankID app 
-activation for the enduser and require that the end user reactivates the BankID app.
+Endpoints are grouped by functionality. RA may implement all or some of these groups, depending on the functionality the RA support. 
 
 # Questions?
 

--- a/bankid-app-api.md
+++ b/bankid-app-api.md
@@ -12,8 +12,6 @@ Please see the BankID Core (COI) documentation for more information regarding th
 Vipps offers an administration API allowing the bank issuing BankIDs to query if an end user has activated BankID app, and to enable/disable the app for a given end user.
 Security is provided by OpenID connect (OIDC) access tokens, issued by BankID OIDC.
 
-[comment]: # (TODO: should be described)
-
 ## BankID RA SPI endpoints required by Vipps
 In order for Vipps to request BankID app to be added as an HA2-mechanism to an enduser's BankID, the bank must implement the SPI 
 described here. 

--- a/bankid-app-api.md
+++ b/bankid-app-api.md
@@ -35,7 +35,7 @@ translated into _FALSE_ when using the .yaml file and that causes errors.
 
 Detailed description of the request endpoints are found in the SPI reference documentation as [Swagger](https://vippsas.github.io/bankid-app-api/) or [ReDoc](https://vippsas.github.io/bankid-app-api/redoc.html).
 
-Endpoints are grouped by functionality. RA may implement all or some of these groups, depending on the functionality the RA support. 
+Endpoints are grouped by functionality. RA may implement all or some of these groups, depending on the functionality the RA supports. 
 
 # Questions?
 

--- a/bankid-app-getting-started.md
+++ b/bankid-app-getting-started.md
@@ -5,17 +5,16 @@ The following information must be provided to BankID support when requesting int
 * Bank register number, i.e. BankID originator ID as found in Norwegian IBAN-BIC Table
 * Bank name
 * Endpoint for RA resource providing OTP activation service as described in [BankID app API guide](https://github.com/vippsas/bankid-app-api/blob/master/bankid-app-api.md).
-* keyId to identify certificate used against this endpoint 
 
 In return we will provide 
 * Address of the Vipps server sending the request to the BankID RA 
 * Certificate for verifying the requests sent by this server
+* A keyid naming the certificate used for the requests sent by this server
 * Administration url, client_id and client_secret to control endusers' BankID app activation status in Vipps 
 * Description of the administration api
+* Signed example request and the public certificate used in preproduction  
 
 Please make sure that the requests from the Vipps server are allowed through firewalls etc. 
-
-The certificate must be assigned a keyId which identifies this certificate in _your_ system. This keyId must be returned to Vipps.
 
 
 [comment]: # (Heter det vipps support eller BankID support ?? )

--- a/bankid-app-getting-started.md
+++ b/bankid-app-getting-started.md
@@ -16,9 +16,3 @@ In return we will provide
 
 Please make sure that the requests from the Vipps server are allowed through firewalls etc. 
 
-
-[comment]: # (Heter det vipps support eller BankID support ?? )
- 
-[comment]: # (Lage sak for generelle header navn ?? )
-
-[comment]: # (url for bapp admin snitt og client id+secret ?? )

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,12 +45,12 @@ const DisableTryItOutPlugin = function() {
   }
 }
 
-<!-- can be tested in IDEA by setting url='swagger.yaml' and open in browser from popup menu -->
+<!-- can be tested in IDEA by setting url='swagger.json' and open in browser from popup menu -->
 
 window.onload = function() {
   // Build a system,
   const ui = SwaggerUIBundle({
-    url: 'https://vippsas.github.io/bankid-app-api/swagger.yaml',
+    url: 'https://vippsas.github.io/bankid-app-api/swagger.json',
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/docs/redoc.html
+++ b/docs/redoc.html
@@ -18,8 +18,8 @@
     </style>
   </head>
   <body>
-    <!-- can be tested in IDEA by setting spec-url='swagger.yaml' and open in browser from popup menu -->
-    <redoc spec-url='https://vippsas.github.io/bankid-app-api/swagger.yaml'></redoc>
+    <!-- can be tested in IDEA by setting spec-url='swagger.json' and open in browser from popup menu -->
+    <redoc spec-url='https://vippsas.github.io/bankid-app-api/swagger.json'></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2,8 +2,8 @@
   "openapi" : "3.0.1",
   "info" : {
     "title" : "BankID RA Service Provider Interface (SPI) for activation of BankID App",
-    "description" : "Defines the interface to be provided by a Registration Authority service to support activation of BankID App as a HA2 element for an end user's Netcentric BankID.<h6>This version corresponds to 'Specification of Solutions for Activation of BankID App as HA2-elements' version v.62</h6>",
-    "version" : "1.3-rc1"
+    "description" : "Defines the interface to be provided by a Registration Authority service to support activation of BankID App as a HA2 element for an end user's Netcentric BankID.<p>An RA implementing the <i>OTP administration</i> group of operations may offer BankID App to all it's end users having a functioning Netcentric BankID with a code device.</p><p>If in addition, the RA implements the <i>Activation without Code Device</i> groups of operations then end users may activate the Bankid App without having another Code Device at all !</p><h6>This SPI version corresponds to the document 'Specification of Solutions for Activation of BankID App as HA2-elements' version v.62</h6>",
+    "version" : "1.3"
   },
   "servers" : [ {
     "url" : "https://ra-preprod.bankidnorge.no/api/enduser/bankid/netcentric/vipps/bapp",
@@ -22,6 +22,71 @@
     "name" : "Activation without Code Device - Self Service"
   } ],
   "paths" : {
+    "/notify_user_of_activation" : {
+      "post" : {
+        "tags" : [ "Activation without Code Device" ],
+        "summary" : "Tell end user that BankID App is activated",
+        "description" : "Request notification of the end user that his BankID App instance is activated",
+        "operationId" : "notifyUserOfActivation",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "description" : "Activation code metadata",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If all ok, no data is returned"
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/selfservice/send_verification_code" : {
       "post" : {
         "tags" : [ "Activation without Code Device - Self Service" ],
@@ -70,6 +135,78 @@
         "responses" : {
           "200" : {
             "description" : "If all ok, no data is returned"
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/selfservice/password_quarantine" : {
+      "post" : {
+        "tags" : [ "Activation without Code Device - Self Service" ],
+        "summary" : "Prohibit change of end user password",
+        "description" : "signal to the RA that self-service activation has reached the point where password change (automated or manual) MUST be prohibited until the provided timestamp, effective immediately.",
+        "operationId" : "selfServicePasswordQuarantine",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "description" : "How long to quarantine the password",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PasswordQuarantineRequestBodyDTO"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Time when password was last reset",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PasswordQuarantineResponseDTO"
+                }
+              }
+            }
           },
           "400" : {
             "description" : "In case of error"
@@ -224,12 +361,12 @@
         }
       }
     },
-    "/notify_user_of_activation" : {
+    "/status" : {
       "post" : {
-        "tags" : [ "Activation without Code Device" ],
-        "summary" : "Tell end user that BankID App is activated",
-        "description" : "Request notification of the end user that his BankID App instance is activated",
-        "operationId" : "notifyUserOfActivation",
+        "tags" : [ "OTP administration" ],
+        "summary" : "Gets the BankID App OTP status for an end user",
+        "description" : "Checks whether an end user has BankID App enabled as an OTP mechanism for at least one of his BankIDs in a given bank",
+        "operationId" : "getBappOtpStatus",
         "parameters" : [ {
           "name" : "Signature",
           "in" : "header",
@@ -259,19 +396,24 @@
           "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
         } ],
         "requestBody" : {
-          "description" : "Activation code metadata",
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
+                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
               }
             }
-          },
-          "required" : true
+          }
         },
         "responses" : {
           "200" : {
-            "description" : "If all ok, no data is returned"
+            "description" : "If status returned is valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StatusBappResponseDTO"
+                }
+              }
+            }
           },
           "400" : {
             "description" : "In case of error"
@@ -281,7 +423,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
                 }
               }
             }
@@ -289,12 +431,28 @@
         }
       }
     },
-    "/selfservice/password_quarantine" : {
+    "/healthcheck" : {
+      "get" : {
+        "tags" : [ "Service availability" ],
+        "summary" : "Health check of the RA application",
+        "description" : "Checks that the RA is capable of handling endpoints declared here",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "RA is healthy"
+          },
+          "500" : {
+            "description" : "RA is not healthy"
+          }
+        }
+      }
+    },
+    "/add" : {
       "post" : {
-        "tags" : [ "Activation without Code Device - Self Service" ],
-        "summary" : "Prohibit change of end user password",
-        "description" : "signal to the RA that self-service activation has reached the point where password change (automated or manual) MUST be prohibited until the provided timestamp, effective immediately.",
-        "operationId" : "selfServicePasswordQuarantine",
+        "tags" : [ "OTP administration" ],
+        "summary" : "Adds BankID App to an end user",
+        "description" : "Adds BankID App to an end user's BankID OTP mechanisms in a given bank",
+        "operationId" : "addBappOtp",
         "parameters" : [ {
           "name" : "Signature",
           "in" : "header",
@@ -324,23 +482,21 @@
           "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
         } ],
         "requestBody" : {
-          "description" : "How long to quarantine the password",
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/PasswordQuarantineRequestBodyDTO"
+                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
               }
             }
-          },
-          "required" : true
+          }
         },
         "responses" : {
           "200" : {
-            "description" : "Time when password was last reset",
+            "description" : "If status returned is valid",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/PasswordQuarantineResponseDTO"
+                  "$ref" : "#/components/schemas/AddBappResponseDTO"
                 }
               }
             }
@@ -430,166 +586,117 @@
           }
         }
       }
-    },
-    "/add" : {
-      "post" : {
-        "tags" : [ "OTP administration" ],
-        "summary" : "Adds BankID App to an end user",
-        "description" : "Adds BankID App to an end user's BankID OTP mechanisms in a given bank",
-        "operationId" : "addBappOtp",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AddBappResponseDTO"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/healthcheck" : {
-      "get" : {
-        "tags" : [ "Service availability" ],
-        "summary" : "Health check of the RA application",
-        "description" : "Checks that the RA is capable of handling endpoints declared here",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "RA is healthy"
-          },
-          "500" : {
-            "description" : "RA is not healthy"
-          }
-        }
-      }
-    },
-    "/status" : {
-      "post" : {
-        "tags" : [ "OTP administration" ],
-        "summary" : "Gets the BankID App OTP status for an end user",
-        "description" : "Checks whether an end user has BankID App enabled as an OTP mechanism for at least one of his BankIDs in a given bank",
-        "operationId" : "getBappOtpStatus",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/StatusBappResponseDTO"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components" : {
     "schemas" : {
+      "NotifyUserOfActivationErrorResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "error" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "unknown_subject", "internal_error" ]
+          }
+        },
+        "description" : "The result of asking an ra to notify a user of activation, used in case of some error"
+      },
+      "ActivationMetadataDTO" : {
+        "type" : "object",
+        "properties" : {
+          "flow" : {
+            "type" : "string",
+            "description" : "The flow used for activation, meanings:<ul><li> - activation_code: A single activation code provided over a secure channel. </li><li> - selfservice: Activation codes provided over two insecure channels. </li><li> - bankid_auth: Activation through a BankID authentication. </li></ul>",
+            "example" : "selfservice",
+            "enum" : [ "activation_code", "selfservice", "bankid_auth" ]
+          },
+          "via_distribution_methods" : {
+            "type" : "array",
+            "description" : "The distribution methods (if any) used during activation.",
+            "items" : {
+              "$ref" : "#/components/schemas/ViaDistributionMethodDTO"
+            }
+          },
+          "locale" : {
+            "type" : "string",
+            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
+            "example" : "en",
+            "enum" : [ "no", "en" ]
+          },
+          "human_readable" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "description" : "Map of localized strings explaining how the device was activated",
+              "example" : "{\"no\":\"med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42\",\"en\":\"using activation codes by email to que***@xyz.no and sms to XXX XX X42\"}"
+            },
+            "description" : "Map of localized strings explaining how the device was activated",
+            "example" : {
+              "no" : "med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42",
+              "en" : "using activation codes by email to que***@xyz.no and sms to XXX XX X42"
+            }
+          }
+        },
+        "description" : "Information about the activation"
+      },
+      "NotifyUserOfActivationRequestBodyDTO" : {
+        "type" : "object",
+        "properties" : {
+          "client_name" : {
+            "type" : "string",
+            "description" : "Name of client sending the request",
+            "example" : "vipps-bapp-client"
+          },
+          "request_id" : {
+            "type" : "string",
+            "description" : "A unique identifier pr. request, used for log correlation",
+            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
+          },
+          "originator_id" : {
+            "type" : "string",
+            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
+            "example" : "9980"
+          },
+          "nnin" : {
+            "type" : "string",
+            "description" : "End user's Norwegian national identification number, string of 11 digits",
+            "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging",
+            "format" : "uuid"
+          },
+          "activationMetadata" : {
+            "$ref" : "#/components/schemas/ActivationMetadataDTO"
+          }
+        },
+        "description" : "Request body content for asking an RA to send a notification to an end user"
+      },
+      "ViaDistributionMethodDTO" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "description" : "Type of distribution",
+            "example" : "email",
+            "enum" : [ "sms", "email", "postal" ]
+          },
+          "hint" : {
+            "type" : "string",
+            "description" : "A censored representation of the user's contact information.<ul><li> - type sms: 6 X's followed by two unmasked digits XXX XX X42<li> - type email:  1-3 unmasked characters + \"(...)\" @ domain.topdomain, eg. dei(...)@gmail.com </li><li> - type official_address: No hint, details on the address must not be exposed. </li></ul>",
+            "example" : "dei(...)@gmail.com"
+          },
+          "originator_ref" : {
+            "type" : "string",
+            "description" : "An RA-specific ID which can be used to track the specific distribution method all the way back to the issuing RA.",
+            "example" : "9980@1234-2f44-123456-12"
+          }
+        },
+        "description" : "Details of one distribution method used during activation."
+      },
       "SimpleErrorResponseDTO" : {
         "type" : "object",
         "properties" : {
@@ -648,6 +755,53 @@
           }
         },
         "description" : "Request body content for asking an RA to send verification code to end user"
+      },
+      "PasswordQuarantineResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "pw_reset_timestamp" : {
+            "type" : "integer",
+            "description" : "Time when user's password was last reset, ms since epoch, UTC",
+            "format" : "int64"
+          }
+        },
+        "description" : "Response when quarantining an end user password"
+      },
+      "PasswordQuarantineRequestBodyDTO" : {
+        "type" : "object",
+        "properties" : {
+          "client_name" : {
+            "type" : "string",
+            "description" : "Name of client sending the request",
+            "example" : "vipps-bapp-client"
+          },
+          "request_id" : {
+            "type" : "string",
+            "description" : "A unique identifier pr. request, used for log correlation",
+            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
+          },
+          "originator_id" : {
+            "type" : "string",
+            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
+            "example" : "9980"
+          },
+          "nnin" : {
+            "type" : "string",
+            "description" : "End user's Norwegian national identification number, string of 11 digits",
+            "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging",
+            "format" : "uuid"
+          },
+          "quarantine_until" : {
+            "type" : "integer",
+            "description" : "Time when quarantine expire, ms since epoch, UTC",
+            "format" : "int64"
+          }
+        },
+        "description" : "Request body content for quarantining the user password"
       },
       "DistributionMethodDTO" : {
         "type" : "object",
@@ -821,170 +975,16 @@
         },
         "description" : "Request body content for asking an RA to send code words to an end user"
       },
-      "NotifyUserOfActivationErrorResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "error" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "unknown_subject", "internal_error" ]
-          }
-        },
-        "description" : "The result of asking an ra to notify a user of activation, used in case of some error"
-      },
-      "ActivationMetadataDTO" : {
-        "type" : "object",
-        "properties" : {
-          "flow" : {
-            "type" : "string",
-            "description" : "The flow used for activation, meanings:<ul><li> - activation_code: A single activation code provided over a secure channel. </li><li> - selfservice: Activation codes provided over two insecure channels. </li><li> - bankid_auth: Activation through a BankID authentication. </li></ul>",
-            "example" : "selfservice",
-            "enum" : [ "activation_code", "selfservice", "bankid_auth" ]
-          },
-          "via_distribution_methods" : {
-            "type" : "array",
-            "description" : "The distribution methods (if any) used during activation.",
-            "items" : {
-              "$ref" : "#/components/schemas/ViaDistributionMethodDTO"
-            }
-          },
-          "locale" : {
-            "type" : "string",
-            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
-            "example" : "en",
-            "enum" : [ "no", "en" ]
-          },
-          "human_readable" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "string",
-              "description" : "Map of localized strings explaining how the device was activated",
-              "example" : "{\"no\":\"med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42\",\"en\":\"using activation codes by email to que***@xyz.no and sms to XXX XX X42\"}"
-            },
-            "description" : "Map of localized strings explaining how the device was activated",
-            "example" : {
-              "no" : "med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42",
-              "en" : "using activation codes by email to que***@xyz.no and sms to XXX XX X42"
-            }
-          }
-        },
-        "description" : "Information about the activation"
-      },
-      "NotifyUserOfActivationRequestBodyDTO" : {
-        "type" : "object",
-        "properties" : {
-          "client_name" : {
-            "type" : "string",
-            "description" : "Name of client sending the request",
-            "example" : "vipps-bapp-client"
-          },
-          "request_id" : {
-            "type" : "string",
-            "description" : "A unique identifier pr. request, used for log correlation",
-            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
-          },
-          "originator_id" : {
-            "type" : "string",
-            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
-            "example" : "9980"
-          },
-          "nnin" : {
-            "type" : "string",
-            "description" : "End user's Norwegian national identification number, string of 11 digits",
-            "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging",
-            "format" : "uuid"
-          },
-          "activationMetadata" : {
-            "$ref" : "#/components/schemas/ActivationMetadataDTO"
-          }
-        },
-        "description" : "Request body content for asking an RA to send a notification to an end user"
-      },
-      "ViaDistributionMethodDTO" : {
-        "type" : "object",
-        "properties" : {
-          "type" : {
-            "type" : "string",
-            "description" : "Type of distribution",
-            "example" : "email",
-            "enum" : [ "sms", "email", "postal" ]
-          },
-          "hint" : {
-            "type" : "string",
-            "description" : "A censored representation of the user's contact information.<ul><li> - type sms: 6 X's followed by two unmasked digits XXX XX X42<li> - type email:  1-3 unmasked characters + \"(...)\" @ domain.topdomain, eg. dei(...)@gmail.com </li><li> - type official_address: No hint, details on the address must not be exposed. </li></ul>",
-            "example" : "dei(...)@gmail.com"
-          },
-          "originator_ref" : {
-            "type" : "string",
-            "description" : "An RA-specific ID which can be used to track the specific distribution method all the way back to the issuing RA.",
-            "example" : "9980@1234-2f44-123456-12"
-          }
-        },
-        "description" : "Details of one distribution method used during activation."
-      },
-      "PasswordQuarantineResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "pw_reset_timestamp" : {
-            "type" : "integer",
-            "description" : "Time when user's password was last reset, ms since epoch, UTC",
-            "format" : "int64"
-          }
-        },
-        "description" : "Response when quarantining an end user password"
-      },
-      "PasswordQuarantineRequestBodyDTO" : {
-        "type" : "object",
-        "properties" : {
-          "client_name" : {
-            "type" : "string",
-            "description" : "Name of client sending the request",
-            "example" : "vipps-bapp-client"
-          },
-          "request_id" : {
-            "type" : "string",
-            "description" : "A unique identifier pr. request, used for log correlation",
-            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
-          },
-          "originator_id" : {
-            "type" : "string",
-            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
-            "example" : "9980"
-          },
-          "nnin" : {
-            "type" : "string",
-            "description" : "End user's Norwegian national identification number, string of 11 digits",
-            "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging",
-            "format" : "uuid"
-          },
-          "quarantine_until" : {
-            "type" : "integer",
-            "description" : "Time when quarantine expire, ms since epoch, UTC",
-            "format" : "int64"
-          }
-        },
-        "description" : "Request body content for quarantining the user password"
-      },
-      "DeleteBappResponseDTO" : {
+      "StatusBappResponseDTO" : {
         "type" : "object",
         "properties" : {
           "status" : {
             "type" : "string",
-            "description" : "Status value for the delete operation <ul><li>DELETED - BAPP was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "DELETED", "NOT_ENABLED", "BLOCKED_IN_ODS" ]
+            "description" : "Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "NOT_ENABLED", "ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
           }
         },
-        "description" : "The result of trying to remove BankID app from an end user's BankID "
+        "description" : "The result of asking if BankID app is enabled for an end user's BankID"
       },
       "AuthenticationBodyDTO" : {
         "type" : "object",
@@ -1023,16 +1023,16 @@
         },
         "description" : "The result of trying to enable BankID app for an end user's BankID"
       },
-      "StatusBappResponseDTO" : {
+      "DeleteBappResponseDTO" : {
         "type" : "object",
         "properties" : {
           "status" : {
             "type" : "string",
-            "description" : "Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "NOT_ENABLED", "ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
+            "description" : "Status value for the delete operation <ul><li>DELETED - BAPP was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "DELETED", "NOT_ENABLED", "BLOCKED_IN_ODS" ]
           }
         },
-        "description" : "The result of asking if BankID app is enabled for an end user's BankID"
+        "description" : "The result of trying to remove BankID app from an end user's BankID "
       }
     }
   }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,9 +3,14 @@ info:
   title: BankID RA Service Provider Interface (SPI) for activation of BankID App
   description: Defines the interface to be provided by a Registration Authority service
     to support activation of BankID App as a HA2 element for an end user's Netcentric
-    BankID.<h6>This version corresponds to 'Specification of Solutions for Activation
-    of BankID App as HA2-elements' version v.62</h6>
-  version: 1.3-rc1
+    BankID.<p>An RA implementing the <i>OTP administration</i> group of operations
+    may offer BankID App to all it's end users having a functioning Netcentric BankID
+    with a code device.</p><p>If in addition, the RA implements the <i>Activation
+    without Code Device</i> groups of operations then end users may activate the Bankid
+    App without having another Code Device at all !</p><h6>This SPI version corresponds
+    to the document 'Specification of Solutions for Activation of BankID App as HA2-elements'
+    version v.62</h6>
+  version: "1.3"
 servers:
 - url: https://ra-preprod.bankidnorge.no/api/enduser/bankid/netcentric/vipps/bapp
   description: Preprod Ra-lite
@@ -18,6 +23,60 @@ tags:
 - name: Activation without Code Device
 - name: Activation without Code Device - Self Service
 paths:
+  /notify_user_of_activation:
+    post:
+      tags:
+      - Activation without Code Device
+      summary: Tell end user that BankID App is activated
+      description: Request notification of the end user that his BankID App instance
+        is activated
+      operationId: notifyUserOfActivation
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        description: Activation code metadata
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
+        required: true
+      responses:
+        200:
+          description: If all ok, no data is returned
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
   /selfservice/send_verification_code:
     post:
       tags:
@@ -67,6 +126,65 @@ paths:
       responses:
         200:
           description: If all ok, no data is returned
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /selfservice/password_quarantine:
+    post:
+      tags:
+      - Activation without Code Device - Self Service
+      summary: Prohibit change of end user password
+      description: signal to the RA that self-service activation has reached the point
+        where password change (automated or manual) MUST be prohibited until the provided
+        timestamp, effective immediately.
+      operationId: selfServicePasswordQuarantine
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        description: How long to quarantine the password
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordQuarantineRequestBodyDTO'
+        required: true
+      responses:
+        200:
+          description: Time when password was last reset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PasswordQuarantineResponseDTO'
         400:
           description: In case of error
         500:
@@ -190,14 +308,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /notify_user_of_activation:
+  /status:
     post:
       tags:
-      - Activation without Code Device
-      summary: Tell end user that BankID App is activated
-      description: Request notification of the end user that his BankID App instance
-        is activated
-      operationId: notifyUserOfActivation
+      - OTP administration
+      summary: Gets the BankID App OTP status for an end user
+      description: Checks whether an end user has BankID App enabled as an OTP mechanism
+        for at least one of his BankIDs in a given bank
+      operationId: getBappOtpStatus
       parameters:
       - name: Signature
         in: header
@@ -227,15 +345,17 @@ paths:
           type: string
         example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
       requestBody:
-        description: Activation code metadata
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
-        required: true
+              $ref: '#/components/schemas/AuthenticationBodyDTO'
       responses:
         200:
-          description: If all ok, no data is returned
+          description: If status returned is valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusBappResponseDTO'
         400:
           description: In case of error
         500:
@@ -243,16 +363,27 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
-  /selfservice/password_quarantine:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /healthcheck:
+    get:
+      tags:
+      - Service availability
+      summary: Health check of the RA application
+      description: Checks that the RA is capable of handling endpoints declared here
+      operationId: healthCheck
+      responses:
+        200:
+          description: RA is healthy
+        500:
+          description: RA is not healthy
+  /add:
     post:
       tags:
-      - Activation without Code Device - Self Service
-      summary: Prohibit change of end user password
-      description: signal to the RA that self-service activation has reached the point
-        where password change (automated or manual) MUST be prohibited until the provided
-        timestamp, effective immediately.
-      operationId: selfServicePasswordQuarantine
+      - OTP administration
+      summary: Adds BankID App to an end user
+      description: Adds BankID App to an end user's BankID OTP mechanisms in a given
+        bank
+      operationId: addBappOtp
       parameters:
       - name: Signature
         in: header
@@ -282,19 +413,17 @@ paths:
           type: string
         example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
       requestBody:
-        description: How long to quarantine the password
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PasswordQuarantineRequestBodyDTO'
-        required: true
+              $ref: '#/components/schemas/AuthenticationBodyDTO'
       responses:
         200:
-          description: Time when password was last reset
+          description: If status returned is valid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PasswordQuarantineResponseDTO'
+                $ref: '#/components/schemas/AddBappResponseDTO'
         400:
           description: In case of error
         500:
@@ -359,132 +488,117 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /add:
-    post:
-      tags:
-      - OTP administration
-      summary: Adds BankID App to an end user
-      description: Adds BankID App to an end user's BankID OTP mechanisms in a given
-        bank
-      operationId: addBappOtp
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationBodyDTO'
-      responses:
-        200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AddBappResponseDTO'
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /healthcheck:
-    get:
-      tags:
-      - Service availability
-      summary: Health check of the RA application
-      description: Checks that the RA is capable of handling endpoints declared here
-      operationId: healthCheck
-      responses:
-        200:
-          description: RA is healthy
-        500:
-          description: RA is not healthy
-  /status:
-    post:
-      tags:
-      - OTP administration
-      summary: Gets the BankID App OTP status for an end user
-      description: Checks whether an end user has BankID App enabled as an OTP mechanism
-        for at least one of his BankIDs in a given bank
-      operationId: getBappOtpStatus
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationBodyDTO'
-      responses:
-        200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StatusBappResponseDTO'
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
 components:
   schemas:
+    NotifyUserOfActivationErrorResponseDTO:
+      type: object
+      properties:
+        error:
+          type: string
+        status:
+          type: string
+          enum:
+          - unknown_subject
+          - internal_error
+      description: The result of asking an ra to notify a user of activation, used
+        in case of some error
+    ActivationMetadataDTO:
+      type: object
+      properties:
+        flow:
+          type: string
+          description: 'The flow used for activation, meanings:<ul><li> - activation_code:
+            A single activation code provided over a secure channel. </li><li> - selfservice:
+            Activation codes provided over two insecure channels. </li><li> - bankid_auth:
+            Activation through a BankID authentication. </li></ul>'
+          example: selfservice
+          enum:
+          - activation_code
+          - selfservice
+          - bankid_auth
+        via_distribution_methods:
+          type: array
+          description: The distribution methods (if any) used during activation.
+          items:
+            $ref: '#/components/schemas/ViaDistributionMethodDTO'
+        locale:
+          type: string
+          description: Locale of initiating app, either "no" for Norwegian and Norwegian
+            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
+            nuisance)</h5>
+          example: en
+          enum:
+          - no
+          - en
+        human_readable:
+          type: object
+          additionalProperties:
+            type: string
+            description: Map of localized strings explaining how the device was activated
+            example: '{"no":"med aktiveringskoder gitt på email til que***@xyz.no
+              og på sms til XXX XX X42","en":"using activation codes by email to que***@xyz.no
+              and sms to XXX XX X42"}'
+          description: Map of localized strings explaining how the device was activated
+          example:
+            no: med aktiveringskoder gitt på email til que***@xyz.no og på sms til
+              XXX XX X42
+            en: using activation codes by email to que***@xyz.no and sms to XXX XX
+              X42
+      description: Information about the activation
+    NotifyUserOfActivationRequestBodyDTO:
+      type: object
+      properties:
+        client_name:
+          type: string
+          description: Name of client sending the request
+          example: vipps-bapp-client
+        request_id:
+          type: string
+          description: A unique identifier pr. request, used for log correlation
+          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
+        originator_id:
+          type: string
+          description: Originator/bank-number for end user's bankID, valid BankID
+            ODS number
+          example: "9980"
+        nnin:
+          type: string
+          description: End user's Norwegian national identification number, string
+            of 11 digits
+          example: "11111111016"
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging
+          format: uuid
+        activationMetadata:
+          $ref: '#/components/schemas/ActivationMetadataDTO'
+      description: Request body content for asking an RA to send a notification to
+        an end user
+    ViaDistributionMethodDTO:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of distribution
+          example: email
+          enum:
+          - sms
+          - email
+          - postal
+        hint:
+          type: string
+          description: 'A censored representation of the user''s contact information.<ul><li>
+            - type sms: 6 X''s followed by two unmasked digits XXX XX X42<li> - type
+            email:  1-3 unmasked characters + "(...)" @ domain.topdomain, eg. dei(...)@gmail.com
+            </li><li> - type official_address: No hint, details on the address must
+            not be exposed. </li></ul>'
+          example: dei(...)@gmail.com
+        originator_ref:
+          type: string
+          description: An RA-specific ID which can be used to track the specific distribution
+            method all the way back to the issuing RA.
+          example: 9980@1234-2f44-123456-12
+      description: Details of one distribution method used during activation.
     SimpleErrorResponseDTO:
       type: object
       properties:
@@ -539,6 +653,44 @@ components:
           format: int64
       description: Request body content for asking an RA to send verification code
         to end user
+    PasswordQuarantineResponseDTO:
+      type: object
+      properties:
+        pw_reset_timestamp:
+          type: integer
+          description: Time when user's password was last reset, ms since epoch, UTC
+          format: int64
+      description: Response when quarantining an end user password
+    PasswordQuarantineRequestBodyDTO:
+      type: object
+      properties:
+        client_name:
+          type: string
+          description: Name of client sending the request
+          example: vipps-bapp-client
+        request_id:
+          type: string
+          description: A unique identifier pr. request, used for log correlation
+          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
+        originator_id:
+          type: string
+          description: Originator/bank-number for end user's bankID, valid BankID
+            ODS number
+          example: "9980"
+        nnin:
+          type: string
+          description: End user's Norwegian national identification number, string
+            of 11 digits
+          example: "11111111016"
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging
+          format: uuid
+        quarantine_until:
+          type: integer
+          description: Time when quarantine expire, ms since epoch, UTC
+          format: int64
+      description: Request body content for quarantining the user password
     DistributionMethodDTO:
       type: object
       properties:
@@ -695,168 +847,26 @@ components:
           format: int64
       description: Request body content for asking an RA to send code words to an
         end user
-    NotifyUserOfActivationErrorResponseDTO:
-      type: object
-      properties:
-        error:
-          type: string
-        status:
-          type: string
-          enum:
-          - unknown_subject
-          - internal_error
-      description: The result of asking an ra to notify a user of activation, used
-        in case of some error
-    ActivationMetadataDTO:
-      type: object
-      properties:
-        flow:
-          type: string
-          description: 'The flow used for activation, meanings:<ul><li> - activation_code:
-            A single activation code provided over a secure channel. </li><li> - selfservice:
-            Activation codes provided over two insecure channels. </li><li> - bankid_auth:
-            Activation through a BankID authentication. </li></ul>'
-          example: selfservice
-          enum:
-          - activation_code
-          - selfservice
-          - bankid_auth
-        via_distribution_methods:
-          type: array
-          description: The distribution methods (if any) used during activation.
-          items:
-            $ref: '#/components/schemas/ViaDistributionMethodDTO'
-        locale:
-          type: string
-          description: Locale of initiating app, either "no" for Norwegian and Norwegian
-            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
-            nuisance)</h5>
-          example: en
-          enum:
-          - no
-          - en
-        human_readable:
-          type: object
-          additionalProperties:
-            type: string
-            description: Map of localized strings explaining how the device was activated
-            example: '{"no":"med aktiveringskoder gitt på email til que***@xyz.no
-              og på sms til XXX XX X42","en":"using activation codes by email to que***@xyz.no
-              and sms to XXX XX X42"}'
-          description: Map of localized strings explaining how the device was activated
-          example:
-            no: med aktiveringskoder gitt på email til que***@xyz.no og på sms til
-              XXX XX X42
-            en: using activation codes by email to que***@xyz.no and sms to XXX XX
-              X42
-      description: Information about the activation
-    NotifyUserOfActivationRequestBodyDTO:
-      type: object
-      properties:
-        client_name:
-          type: string
-          description: Name of client sending the request
-          example: vipps-bapp-client
-        request_id:
-          type: string
-          description: A unique identifier pr. request, used for log correlation
-          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
-        originator_id:
-          type: string
-          description: Originator/bank-number for end user's bankID, valid BankID
-            ODS number
-          example: "9980"
-        nnin:
-          type: string
-          description: End user's Norwegian national identification number, string
-            of 11 digits
-          example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging
-          format: uuid
-        activationMetadata:
-          $ref: '#/components/schemas/ActivationMetadataDTO'
-      description: Request body content for asking an RA to send a notification to
-        an end user
-    ViaDistributionMethodDTO:
-      type: object
-      properties:
-        type:
-          type: string
-          description: Type of distribution
-          example: email
-          enum:
-          - sms
-          - email
-          - postal
-        hint:
-          type: string
-          description: 'A censored representation of the user''s contact information.<ul><li>
-            - type sms: 6 X''s followed by two unmasked digits XXX XX X42<li> - type
-            email:  1-3 unmasked characters + "(...)" @ domain.topdomain, eg. dei(...)@gmail.com
-            </li><li> - type official_address: No hint, details on the address must
-            not be exposed. </li></ul>'
-          example: dei(...)@gmail.com
-        originator_ref:
-          type: string
-          description: An RA-specific ID which can be used to track the specific distribution
-            method all the way back to the issuing RA.
-          example: 9980@1234-2f44-123456-12
-      description: Details of one distribution method used during activation.
-    PasswordQuarantineResponseDTO:
-      type: object
-      properties:
-        pw_reset_timestamp:
-          type: integer
-          description: Time when user's password was last reset, ms since epoch, UTC
-          format: int64
-      description: Response when quarantining an end user password
-    PasswordQuarantineRequestBodyDTO:
-      type: object
-      properties:
-        client_name:
-          type: string
-          description: Name of client sending the request
-          example: vipps-bapp-client
-        request_id:
-          type: string
-          description: A unique identifier pr. request, used for log correlation
-          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
-        originator_id:
-          type: string
-          description: Originator/bank-number for end user's bankID, valid BankID
-            ODS number
-          example: "9980"
-        nnin:
-          type: string
-          description: End user's Norwegian national identification number, string
-            of 11 digits
-          example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging
-          format: uuid
-        quarantine_until:
-          type: integer
-          description: Time when quarantine expire, ms since epoch, UTC
-          format: int64
-      description: Request body content for quarantining the user password
-    DeleteBappResponseDTO:
+    StatusBappResponseDTO:
       type: object
       properties:
         status:
           type: string
-          description: Status value for the delete operation <ul><li>DELETED - BAPP
-            was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled
-            for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't
-            deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>
+          description: Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP
+            is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the
+            end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE
+            - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user
+            is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected
+            to the BankID, but was blocked by ODS because of wrong attempts</li></ul>
           enum:
-          - DELETED
           - NOT_ENABLED
+          - ENABLED
+          - NOT_AVAILABLE
+          - BANK_ID_NOT_AVAILABLE
+          - BLOCKED_BY_BANK
           - BLOCKED_IN_ODS
-      description: 'The result of trying to remove BankID app from an end user''s
-        BankID '
+      description: The result of asking if BankID app is enabled for an end user's
+        BankID
     AuthenticationBodyDTO:
       type: object
       properties:
@@ -900,23 +910,18 @@ components:
           - BLOCKED_BY_BANK
           - BLOCKED_IN_ODS
       description: The result of trying to enable BankID app for an end user's BankID
-    StatusBappResponseDTO:
+    DeleteBappResponseDTO:
       type: object
       properties:
         status:
           type: string
-          description: Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP
-            is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the
-            end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE
-            - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user
-            is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected
-            to the BankID, but was blocked by ODS because of wrong attempts</li></ul>
+          description: Status value for the delete operation <ul><li>DELETED - BAPP
+            was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled
+            for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't
+            deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>
           enum:
+          - DELETED
           - NOT_ENABLED
-          - ENABLED
-          - NOT_AVAILABLE
-          - BANK_ID_NOT_AVAILABLE
-          - BLOCKED_BY_BANK
           - BLOCKED_IN_ODS
-      description: The result of asking if BankID app is enabled for an end user's
-        BankID
+      description: 'The result of trying to remove BankID app from an end user''s
+        BankID '

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
@@ -30,7 +30,16 @@ import static no.bankid.outgoing.ra.HttpSignatureHeaders.SIGNATURE;
                 version = "1.3-rc1",
                 description = "Defines the interface to be provided by a Registration Authority service to " +
                         "support activation of BankID App as a HA2 element for an end user's Netcentric BankID." +
-                        "<h6>This version corresponds to " +
+                        "<p>" +
+                        "An RA implementing the <i>OTP administration</i> group of operations may offer BankID App " +
+                        "to all it's end users having a functioning Netcentric BankID with a code device." +
+                        "</p>" +
+                        "<p>" +
+                        "If in addition, the RA implements the <i>Activation without Code Device</i> " +
+                        "groups of operations then end users may activate the Bankid App without having " +
+                        "another Code Device at all !" +
+                        "</p>" +
+                        "<h6>This SPI version corresponds to the document " +
                         "'Specification of Solutions for Activation of BankID App as HA2-elements' version v.62</h6>"
         ),
         tags = {

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/StatusBappResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/StatusBappResponseDTO.java
@@ -7,10 +7,10 @@ public class StatusBappResponseDTO {
     @Schema(description = "Status value for end user's BAPP " +
             "<ul>" +
             "<li>NOT_ENABLED - BAPP is not enabled, but could be</li>" +
-            "<li>ENABLED - BAPP is enabled for the endUser</li>" +
+            "<li>ENABLED - BAPP is enabled for the end user</li>" +
             "<li>NOT_AVAILABLE - BAPP is not available for the bank</li>" +
-            "<li>BANK_ID_NOT_AVAILABLE - endUser doesn't have active BankID</li>" +
-            "<li>BLOCKED_BY_BANK - endUser is not allowed to use BAPP</li>" +
+            "<li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li>" +
+            "<li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li>" +
             "<li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li>" +
             "</ul>")
     public enum Result {

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/StatusBappResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/StatusBappResponseDTO.java
@@ -7,10 +7,10 @@ public class StatusBappResponseDTO {
     @Schema(description = "Status value for end user's BAPP " +
             "<ul>" +
             "<li>NOT_ENABLED - BAPP is not enabled, but could be</li>" +
-            "<li>ENABLED - BAPP is enabled for the end user</li>" +
+            "<li>ENABLED - BAPP is enabled for the endUser</li>" +
             "<li>NOT_AVAILABLE - BAPP is not available for the bank</li>" +
-            "<li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li>" +
-            "<li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li>" +
+            "<li>BANK_ID_NOT_AVAILABLE - endUser doesn't have active BankID</li>" +
+            "<li>BLOCKED_BY_BANK - endUser is not allowed to use BAPP</li>" +
             "<li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li>" +
             "</ul>")
     public enum Result {


### PR DESCRIPTION
Removed all descriptions for use of X_CUSTOMER_ID e.al.

Added a few lines of what an RA need to implement.

KeyId is now a value which we set, not a value that the RA decides.