### PR TITLE
BAPP-1245: added status to check user response, fixed camelcase in fi…

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "BankID RA Service Provider Interface (SPI) for activation of BankID App",
     "description" : "Defines the interface to be provided by a Registration Authority service to support activation of BankID App as a HA2 element for an end user's Netcentric BankID.<p>An RA implementing the <i>OTP administration</i> group of operations may offer BankID App to all it's end users having a functioning Netcentric BankID with a code device.</p><p>If in addition, the RA implements the <i>Activation without Code Device</i> groups of operations then end users may activate the Bankid App without having another Code Device at all !</p><h6>This SPI version corresponds to the document 'Specification of Solutions for Activation of BankID App as HA2-elements' version v.62</h6>",
-    "version" : "1.3"
+    "version" : "1.3-rc1"
   },
   "servers" : [ {
     "url" : "https://ra-preprod.bankidnorge.no/api/enduser/bankid/netcentric/vipps/bapp",
@@ -22,71 +22,6 @@
     "name" : "Activation without Code Device - Self Service"
   } ],
   "paths" : {
-    "/notify_user_of_activation" : {
-      "post" : {
-        "tags" : [ "Activation without Code Device" ],
-        "summary" : "Tell end user that BankID App is activated",
-        "description" : "Request notification of the end user that his BankID App instance is activated",
-        "operationId" : "notifyUserOfActivation",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "description" : "Activation code metadata",
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If all ok, no data is returned"
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/selfservice/send_verification_code" : {
       "post" : {
         "tags" : [ "Activation without Code Device - Self Service" ],
@@ -224,12 +159,12 @@
         }
       }
     },
-    "/selfservice/check_user" : {
+    "/notify_user_of_activation" : {
       "post" : {
-        "tags" : [ "Activation without Code Device - Self Service" ],
-        "summary" : "Check two-channel options for end user",
-        "description" : "<p>Endpoint to check if a specific user is eligible from single originator for self-service activation.</p><p>The RA should check if the provided phone number is registered for the user, but return the other information regardless.",
-        "operationId" : "selfServiceCheckUser",
+        "tags" : [ "Activation without Code Device" ],
+        "summary" : "Tell end user that BankID App is activated",
+        "description" : "Request notification of the end user that his BankID App instance is activated",
+        "operationId" : "notifyUserOfActivation",
         "parameters" : [ {
           "name" : "Signature",
           "in" : "header",
@@ -259,11 +194,11 @@
           "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
         } ],
         "requestBody" : {
-          "description" : "Activation code and how to distribute",
+          "description" : "Activation code metadata",
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/SelfServiceCheckUserRequestBodyDTO"
+                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
               }
             }
           },
@@ -271,14 +206,7 @@
         },
         "responses" : {
           "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SelfServiceCheckUserResponseDTO"
-                }
-              }
-            }
+            "description" : "If all ok, no data is returned"
           },
           "400" : {
             "description" : "In case of error"
@@ -288,7 +216,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
                 }
               }
             }
@@ -361,12 +289,12 @@
         }
       }
     },
-    "/status" : {
+    "/selfservice/check_user" : {
       "post" : {
-        "tags" : [ "OTP administration" ],
-        "summary" : "Gets the BankID App OTP status for an end user",
-        "description" : "Checks whether an end user has BankID App enabled as an OTP mechanism for at least one of his BankIDs in a given bank",
-        "operationId" : "getBappOtpStatus",
+        "tags" : [ "Activation without Code Device - Self Service" ],
+        "summary" : "Check two-channel options for end user",
+        "description" : "<p>Endpoint to check if a specific user is eligible from single originator for self-service activation.</p><p>The RA should check if the provided phone number is registered for the user, but return the other information regardless.",
+        "operationId" : "selfServiceCheckUser",
         "parameters" : [ {
           "name" : "Signature",
           "in" : "header",
@@ -396,13 +324,15 @@
           "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
         } ],
         "requestBody" : {
+          "description" : "Activation code and how to distribute",
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
+                "$ref" : "#/components/schemas/SelfServiceCheckUserRequestBodyDTO"
               }
             }
-          }
+          },
+          "required" : true
         },
         "responses" : {
           "200" : {
@@ -410,7 +340,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StatusBappResponseDTO"
+                  "$ref" : "#/components/schemas/SelfServiceCheckUserResponseDTO"
                 }
               }
             }
@@ -427,22 +357,6 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/healthcheck" : {
-      "get" : {
-        "tags" : [ "Service availability" ],
-        "summary" : "Health check of the RA application",
-        "description" : "Checks that the RA is capable of handling endpoints declared here",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "RA is healthy"
-          },
-          "500" : {
-            "description" : "RA is not healthy"
           }
         }
       }
@@ -586,117 +500,96 @@
           }
         }
       }
+    },
+    "/status" : {
+      "post" : {
+        "tags" : [ "OTP administration" ],
+        "summary" : "Gets the BankID App OTP status for an end user",
+        "description" : "Checks whether an end user has BankID App enabled as an OTP mechanism for at least one of his BankIDs in a given bank",
+        "operationId" : "getBappOtpStatus",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If status returned is valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StatusBappResponseDTO"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/healthcheck" : {
+      "get" : {
+        "tags" : [ "Service availability" ],
+        "summary" : "Health check of the RA application",
+        "description" : "Checks that the RA is capable of handling endpoints declared here",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "RA is healthy"
+          },
+          "500" : {
+            "description" : "RA is not healthy"
+          }
+        }
+      }
     }
   },
   "components" : {
     "schemas" : {
-      "NotifyUserOfActivationErrorResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "error" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "unknown_subject", "internal_error" ]
-          }
-        },
-        "description" : "The result of asking an ra to notify a user of activation, used in case of some error"
-      },
-      "ActivationMetadataDTO" : {
-        "type" : "object",
-        "properties" : {
-          "flow" : {
-            "type" : "string",
-            "description" : "The flow used for activation, meanings:<ul><li> - activation_code: A single activation code provided over a secure channel. </li><li> - selfservice: Activation codes provided over two insecure channels. </li><li> - bankid_auth: Activation through a BankID authentication. </li></ul>",
-            "example" : "selfservice",
-            "enum" : [ "activation_code", "selfservice", "bankid_auth" ]
-          },
-          "via_distribution_methods" : {
-            "type" : "array",
-            "description" : "The distribution methods (if any) used during activation.",
-            "items" : {
-              "$ref" : "#/components/schemas/ViaDistributionMethodDTO"
-            }
-          },
-          "locale" : {
-            "type" : "string",
-            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
-            "example" : "en",
-            "enum" : [ "no", "en" ]
-          },
-          "human_readable" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "string",
-              "description" : "Map of localized strings explaining how the device was activated",
-              "example" : "{\"no\":\"med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42\",\"en\":\"using activation codes by email to que***@xyz.no and sms to XXX XX X42\"}"
-            },
-            "description" : "Map of localized strings explaining how the device was activated",
-            "example" : {
-              "no" : "med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42",
-              "en" : "using activation codes by email to que***@xyz.no and sms to XXX XX X42"
-            }
-          }
-        },
-        "description" : "Information about the activation"
-      },
-      "NotifyUserOfActivationRequestBodyDTO" : {
-        "type" : "object",
-        "properties" : {
-          "client_name" : {
-            "type" : "string",
-            "description" : "Name of client sending the request",
-            "example" : "vipps-bapp-client"
-          },
-          "request_id" : {
-            "type" : "string",
-            "description" : "A unique identifier pr. request, used for log correlation",
-            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
-          },
-          "originator_id" : {
-            "type" : "string",
-            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
-            "example" : "9980"
-          },
-          "nnin" : {
-            "type" : "string",
-            "description" : "End user's Norwegian national identification number, string of 11 digits",
-            "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging",
-            "format" : "uuid"
-          },
-          "activationMetadata" : {
-            "$ref" : "#/components/schemas/ActivationMetadataDTO"
-          }
-        },
-        "description" : "Request body content for asking an RA to send a notification to an end user"
-      },
-      "ViaDistributionMethodDTO" : {
-        "type" : "object",
-        "properties" : {
-          "type" : {
-            "type" : "string",
-            "description" : "Type of distribution",
-            "example" : "email",
-            "enum" : [ "sms", "email", "postal" ]
-          },
-          "hint" : {
-            "type" : "string",
-            "description" : "A censored representation of the user's contact information.<ul><li> - type sms: 6 X's followed by two unmasked digits XXX XX X42<li> - type email:  1-3 unmasked characters + \"(...)\" @ domain.topdomain, eg. dei(...)@gmail.com </li><li> - type official_address: No hint, details on the address must not be exposed. </li></ul>",
-            "example" : "dei(...)@gmail.com"
-          },
-          "originator_ref" : {
-            "type" : "string",
-            "description" : "An RA-specific ID which can be used to track the specific distribution method all the way back to the issuing RA.",
-            "example" : "9980@1234-2f44-123456-12"
-          }
-        },
-        "description" : "Details of one distribution method used during activation."
-      },
       "SimpleErrorResponseDTO" : {
         "type" : "object",
         "properties" : {
@@ -803,6 +696,163 @@
         },
         "description" : "Request body content for quarantining the user password"
       },
+      "NotifyUserOfActivationErrorResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "error" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "unknown_subject", "internal_error" ]
+          }
+        },
+        "description" : "The result of asking an ra to notify a user of activation, used in case of some error"
+      },
+      "ActivationMetadataDTO" : {
+        "type" : "object",
+        "properties" : {
+          "flow" : {
+            "type" : "string",
+            "description" : "The flow used for activation, meanings:<ul><li> - activation_code: A single activation code provided over a secure channel. </li><li> - selfservice: Activation codes provided over two insecure channels. </li><li> - bankid_auth: Activation through a BankID authentication. </li></ul>",
+            "example" : "selfservice",
+            "enum" : [ "activation_code", "selfservice", "bankid_auth" ]
+          },
+          "via_distribution_methods" : {
+            "type" : "array",
+            "description" : "The distribution methods (if any) used during activation.",
+            "items" : {
+              "$ref" : "#/components/schemas/ViaDistributionMethodDTO"
+            }
+          },
+          "locale" : {
+            "type" : "string",
+            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
+            "example" : "en",
+            "enum" : [ "no", "en" ]
+          },
+          "human_readable" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "description" : "Map of localized strings explaining how the device was activated",
+              "example" : "{\"no\":\"med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42\",\"en\":\"using activation codes by email to que***@xyz.no and sms to XXX XX X42\"}"
+            },
+            "description" : "Map of localized strings explaining how the device was activated",
+            "example" : {
+              "no" : "med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42",
+              "en" : "using activation codes by email to que***@xyz.no and sms to XXX XX X42"
+            }
+          }
+        },
+        "description" : "Information about the activation"
+      },
+      "NotifyUserOfActivationRequestBodyDTO" : {
+        "type" : "object",
+        "properties" : {
+          "client_name" : {
+            "type" : "string",
+            "description" : "Name of client sending the request",
+            "example" : "vipps-bapp-client"
+          },
+          "request_id" : {
+            "type" : "string",
+            "description" : "A unique identifier pr. request, used for log correlation",
+            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
+          },
+          "originator_id" : {
+            "type" : "string",
+            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
+            "example" : "9980"
+          },
+          "nnin" : {
+            "type" : "string",
+            "description" : "End user's Norwegian national identification number, string of 11 digits",
+            "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging",
+            "format" : "uuid"
+          },
+          "activation_metadata" : {
+            "$ref" : "#/components/schemas/ActivationMetadataDTO"
+          }
+        },
+        "description" : "Request body content for asking an RA to send a notification to an end user"
+      },
+      "ViaDistributionMethodDTO" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "description" : "Type of distribution",
+            "example" : "email",
+            "enum" : [ "sms", "email", "postal" ]
+          },
+          "hint" : {
+            "type" : "string",
+            "description" : "A censored representation of the user's contact information.<ul><li> - type sms: 6 X's followed by two unmasked digits XXX XX X42<li> - type email:  1-3 unmasked characters + \"(...)\" @ domain.topdomain, eg. dei(...)@gmail.com </li><li> - type official_address: No hint, details on the address must not be exposed. </li></ul>",
+            "example" : "dei(...)@gmail.com"
+          },
+          "originator_ref" : {
+            "type" : "string",
+            "description" : "An RA-specific ID which can be used to track the specific distribution method all the way back to the issuing RA.",
+            "example" : "9980@1234-2f44-123456-12"
+          }
+        },
+        "description" : "Details of one distribution method used during activation."
+      },
+      "SendCodeWordsRequestBodyDTO" : {
+        "type" : "object",
+        "properties" : {
+          "client_name" : {
+            "type" : "string",
+            "description" : "Name of client sending the request",
+            "example" : "vipps-bapp-client"
+          },
+          "request_id" : {
+            "type" : "string",
+            "description" : "A unique identifier pr. request, used for log correlation",
+            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
+          },
+          "originator_id" : {
+            "type" : "string",
+            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
+            "example" : "9980"
+          },
+          "nnin" : {
+            "type" : "string",
+            "description" : "End user's Norwegian national identification number, string of 11 digits",
+            "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging, will be the same for both codes",
+            "format" : "uuid"
+          },
+          "distribution_method" : {
+            "type" : "string",
+            "description" : "One of the method identifiers returned from selfservice/check_user call"
+          },
+          "locale" : {
+            "type" : "string",
+            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
+            "example" : "en",
+            "enum" : [ "no", "en" ]
+          },
+          "code_words" : {
+            "type" : "string",
+            "description" : "The two code words to distribute"
+          },
+          "exp" : {
+            "type" : "integer",
+            "description" : "Time when code expire, ms since epoch, UTC",
+            "format" : "int64"
+          }
+        },
+        "description" : "Request body content for asking an RA to send code words to an end user"
+      },
       "DistributionMethodDTO" : {
         "type" : "object",
         "properties" : {
@@ -870,6 +920,11 @@
             "items" : {
               "$ref" : "#/components/schemas/DistributionMethodDTO"
             }
+          },
+          "status" : {
+            "type" : "string",
+            "description" : "Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "NOT_ENABLED", "ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
           }
         },
         "description" : "The result of querying RA about end user distribution methods"
@@ -925,66 +980,16 @@
         },
         "description" : "Request body content for asking an RA about end user distribution methods"
       },
-      "SendCodeWordsRequestBodyDTO" : {
-        "type" : "object",
-        "properties" : {
-          "client_name" : {
-            "type" : "string",
-            "description" : "Name of client sending the request",
-            "example" : "vipps-bapp-client"
-          },
-          "request_id" : {
-            "type" : "string",
-            "description" : "A unique identifier pr. request, used for log correlation",
-            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
-          },
-          "originator_id" : {
-            "type" : "string",
-            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
-            "example" : "9980"
-          },
-          "nnin" : {
-            "type" : "string",
-            "description" : "End user's Norwegian national identification number, string of 11 digits",
-            "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging, will be the same for both codes",
-            "format" : "uuid"
-          },
-          "distribution_method" : {
-            "type" : "string",
-            "description" : "One of the method identifiers returned from selfservice/check_user call"
-          },
-          "locale" : {
-            "type" : "string",
-            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
-            "example" : "en",
-            "enum" : [ "no", "en" ]
-          },
-          "code_words" : {
-            "type" : "string",
-            "description" : "The two code words to distribute"
-          },
-          "exp" : {
-            "type" : "integer",
-            "description" : "Time when code expire, ms since epoch, UTC",
-            "format" : "int64"
-          }
-        },
-        "description" : "Request body content for asking an RA to send code words to an end user"
-      },
-      "StatusBappResponseDTO" : {
+      "AddBappResponseDTO" : {
         "type" : "object",
         "properties" : {
           "status" : {
             "type" : "string",
-            "description" : "Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "NOT_ENABLED", "ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
+            "description" : "Status value for add operation<ul><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "ENABLED", "NOT_ENABLED", "ALREADY_ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
           }
         },
-        "description" : "The result of asking if BankID app is enabled for an end user's BankID"
+        "description" : "The result of trying to enable BankID app for an end user's BankID"
       },
       "AuthenticationBodyDTO" : {
         "type" : "object",
@@ -1012,17 +1017,6 @@
         },
         "description" : "Minimal body for authenticating and authorizing a request"
       },
-      "AddBappResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "status" : {
-            "type" : "string",
-            "description" : "Status value for add operation<ul><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "ENABLED", "NOT_ENABLED", "ALREADY_ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
-          }
-        },
-        "description" : "The result of trying to enable BankID app for an end user's BankID"
-      },
       "DeleteBappResponseDTO" : {
         "type" : "object",
         "properties" : {
@@ -1033,6 +1027,17 @@
           }
         },
         "description" : "The result of trying to remove BankID app from an end user's BankID "
+      },
+      "StatusBappResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "string",
+            "description" : "Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "NOT_ENABLED", "ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
+          }
+        },
+        "description" : "The result of asking if BankID app is enabled for an end user's BankID"
       }
     }
   }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -22,6 +22,143 @@
     "name" : "Activation without Code Device - Self Service"
   } ],
   "paths" : {
+    "/notify_user_of_activation" : {
+      "post" : {
+        "tags" : [ "Activation without Code Device" ],
+        "summary" : "Tell end user that BankID App is activated",
+        "description" : "Request notification of the end user that his BankID App instance is activated",
+        "operationId" : "notifyUserOfActivation",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "description" : "Activation code metadata",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If all ok, no data is returned"
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/selfservice/check_user" : {
+      "post" : {
+        "tags" : [ "Activation without Code Device - Self Service" ],
+        "summary" : "Check two-channel options for end user",
+        "description" : "<p>Endpoint to check if a specific user is eligible from single originator for self-service activation.</p><p>The RA should check if the provided phone number is registered for the user, but return the other information regardless.",
+        "operationId" : "selfServiceCheckUser",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "description" : "Activation code and how to distribute",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SelfServiceCheckUserRequestBodyDTO"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If status returned is valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SelfServiceCheckUserResponseDTO"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/selfservice/send_verification_code" : {
       "post" : {
         "tags" : [ "Activation without Code Device - Self Service" ],
@@ -62,6 +199,71 @@
             "application/json" : {
               "schema" : {
                 "$ref" : "#/components/schemas/SendVerificationCodeRequestBodyDTO"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If all ok, no data is returned"
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/selfservice/send_code_words" : {
+      "post" : {
+        "tags" : [ "Activation without Code Device - Self Service" ],
+        "summary" : "Send codewords to an end user",
+        "description" : "request distribution of code words to be sent to a user. Upon receiving a request on this end-point, the RA should distribute the provided code through the channel indicated, or return an error-code.",
+        "operationId" : "selfServiceSendCodeWords",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "description" : "Activation codes and how to distribute",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SendCodeWordsRequestBodyDTO"
               }
             }
           },
@@ -159,208 +361,6 @@
         }
       }
     },
-    "/notify_user_of_activation" : {
-      "post" : {
-        "tags" : [ "Activation without Code Device" ],
-        "summary" : "Tell end user that BankID App is activated",
-        "description" : "Request notification of the end user that his BankID App instance is activated",
-        "operationId" : "notifyUserOfActivation",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "description" : "Activation code metadata",
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If all ok, no data is returned"
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/selfservice/send_code_words" : {
-      "post" : {
-        "tags" : [ "Activation without Code Device - Self Service" ],
-        "summary" : "Send codewords to an end user",
-        "description" : "request distribution of code words to be sent to a user. Upon receiving a request on this end-point, the RA should distribute the provided code through the channel indicated, or return an error-code.",
-        "operationId" : "selfServiceSendCodeWords",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "description" : "Activation codes and how to distribute",
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SendCodeWordsRequestBodyDTO"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If all ok, no data is returned"
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/selfservice/check_user" : {
-      "post" : {
-        "tags" : [ "Activation without Code Device - Self Service" ],
-        "summary" : "Check two-channel options for end user",
-        "description" : "<p>Endpoint to check if a specific user is eligible from single originator for self-service activation.</p><p>The RA should check if the provided phone number is registered for the user, but return the other information regardless.",
-        "operationId" : "selfServiceCheckUser",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "description" : "Activation code and how to distribute",
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SelfServiceCheckUserRequestBodyDTO"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SelfServiceCheckUserResponseDTO"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/add" : {
       "post" : {
         "tags" : [ "OTP administration" ],
@@ -411,76 +411,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/AddBappResponseDTO"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/remove" : {
-      "post" : {
-        "tags" : [ "OTP administration" ],
-        "summary" : "Removes BankID App from an end user",
-        "description" : "Removes BankID App as an end user's OTP mechanism for at least one of his BankIDs in a given bank",
-        "operationId" : "removeBappOtp",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/DeleteBappResponseDTO"
                 }
               }
             }
@@ -571,6 +501,76 @@
         }
       }
     },
+    "/remove" : {
+      "post" : {
+        "tags" : [ "OTP administration" ],
+        "summary" : "Removes BankID App from an end user",
+        "description" : "Removes BankID App as an end user's OTP mechanism for at least one of his BankIDs in a given bank",
+        "operationId" : "removeBappOtp",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If status returned is valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DeleteBappResponseDTO"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/healthcheck" : {
       "get" : {
         "tags" : [ "Service availability" ],
@@ -590,112 +590,6 @@
   },
   "components" : {
     "schemas" : {
-      "SimpleErrorResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "error" : {
-            "type" : "string"
-          }
-        },
-        "description" : "Result when there is only an error code in return"
-      },
-      "SendVerificationCodeRequestBodyDTO" : {
-        "type" : "object",
-        "properties" : {
-          "client_name" : {
-            "type" : "string",
-            "description" : "Name of client sending the request",
-            "example" : "vipps-bapp-client"
-          },
-          "request_id" : {
-            "type" : "string",
-            "description" : "A unique identifier pr. request, used for log correlation",
-            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
-          },
-          "originator_id" : {
-            "type" : "string",
-            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
-            "example" : "9980"
-          },
-          "nnin" : {
-            "type" : "string",
-            "description" : "End user's Norwegian national identification number, string of 11 digits",
-            "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging, will be the same for both codes",
-            "format" : "uuid"
-          },
-          "msisdn_reference_id" : {
-            "type" : "string",
-            "description" : "The alias for the msisdn previously provided in a response from check-user"
-          },
-          "locale" : {
-            "type" : "string",
-            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
-            "example" : "en",
-            "enum" : [ "no", "en" ]
-          },
-          "verification_code" : {
-            "type" : "string",
-            "description" : "Four digit code"
-          },
-          "exp" : {
-            "type" : "integer",
-            "description" : "Time when code expire, ms since epoch, UTC",
-            "format" : "int64"
-          }
-        },
-        "description" : "Request body content for asking an RA to send verification code to end user"
-      },
-      "PasswordQuarantineResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "pw_reset_timestamp" : {
-            "type" : "integer",
-            "description" : "Time when user's password was last reset, ms since epoch, UTC",
-            "format" : "int64"
-          }
-        },
-        "description" : "Response when quarantining an end user password"
-      },
-      "PasswordQuarantineRequestBodyDTO" : {
-        "type" : "object",
-        "properties" : {
-          "client_name" : {
-            "type" : "string",
-            "description" : "Name of client sending the request",
-            "example" : "vipps-bapp-client"
-          },
-          "request_id" : {
-            "type" : "string",
-            "description" : "A unique identifier pr. request, used for log correlation",
-            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
-          },
-          "originator_id" : {
-            "type" : "string",
-            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
-            "example" : "9980"
-          },
-          "nnin" : {
-            "type" : "string",
-            "description" : "End user's Norwegian national identification number, string of 11 digits",
-            "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging",
-            "format" : "uuid"
-          },
-          "quarantine_until" : {
-            "type" : "integer",
-            "description" : "Time when quarantine expire, ms since epoch, UTC",
-            "format" : "int64"
-          }
-        },
-        "description" : "Request body content for quarantining the user password"
-      },
       "NotifyUserOfActivationErrorResponseDTO" : {
         "type" : "object",
         "properties" : {
@@ -803,56 +697,6 @@
         },
         "description" : "Details of one distribution method used during activation."
       },
-      "SendCodeWordsRequestBodyDTO" : {
-        "type" : "object",
-        "properties" : {
-          "client_name" : {
-            "type" : "string",
-            "description" : "Name of client sending the request",
-            "example" : "vipps-bapp-client"
-          },
-          "request_id" : {
-            "type" : "string",
-            "description" : "A unique identifier pr. request, used for log correlation",
-            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
-          },
-          "originator_id" : {
-            "type" : "string",
-            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
-            "example" : "9980"
-          },
-          "nnin" : {
-            "type" : "string",
-            "description" : "End user's Norwegian national identification number, string of 11 digits",
-            "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging, will be the same for both codes",
-            "format" : "uuid"
-          },
-          "distribution_method" : {
-            "type" : "string",
-            "description" : "One of the method identifiers returned from selfservice/check_user call"
-          },
-          "locale" : {
-            "type" : "string",
-            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
-            "example" : "en",
-            "enum" : [ "no", "en" ]
-          },
-          "code_words" : {
-            "type" : "string",
-            "description" : "The two code words to distribute"
-          },
-          "exp" : {
-            "type" : "integer",
-            "description" : "Time when code expire, ms since epoch, UTC",
-            "format" : "int64"
-          }
-        },
-        "description" : "Request body content for asking an RA to send code words to an end user"
-      },
       "DistributionMethodDTO" : {
         "type" : "object",
         "properties" : {
@@ -929,6 +773,15 @@
         },
         "description" : "The result of querying RA about end user distribution methods"
       },
+      "SimpleErrorResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "error" : {
+            "type" : "string"
+          }
+        },
+        "description" : "Result when there is only an error code in return"
+      },
       "MsisdnDTO" : {
         "type" : "object",
         "properties" : {
@@ -980,6 +833,153 @@
         },
         "description" : "Request body content for asking an RA about end user distribution methods"
       },
+      "SendVerificationCodeRequestBodyDTO" : {
+        "type" : "object",
+        "properties" : {
+          "client_name" : {
+            "type" : "string",
+            "description" : "Name of client sending the request",
+            "example" : "vipps-bapp-client"
+          },
+          "request_id" : {
+            "type" : "string",
+            "description" : "A unique identifier pr. request, used for log correlation",
+            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
+          },
+          "originator_id" : {
+            "type" : "string",
+            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
+            "example" : "9980"
+          },
+          "nnin" : {
+            "type" : "string",
+            "description" : "End user's Norwegian national identification number, string of 11 digits",
+            "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging, will be the same for both codes",
+            "format" : "uuid"
+          },
+          "msisdn_reference_id" : {
+            "type" : "string",
+            "description" : "The alias for the msisdn previously provided in a response from check-user"
+          },
+          "locale" : {
+            "type" : "string",
+            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
+            "example" : "en",
+            "enum" : [ "no", "en" ]
+          },
+          "verification_code" : {
+            "type" : "string",
+            "description" : "Four digit code"
+          },
+          "exp" : {
+            "type" : "integer",
+            "description" : "Time when code expire, ms since epoch, UTC",
+            "format" : "int64"
+          }
+        },
+        "description" : "Request body content for asking an RA to send verification code to end user"
+      },
+      "SendCodeWordsRequestBodyDTO" : {
+        "type" : "object",
+        "properties" : {
+          "client_name" : {
+            "type" : "string",
+            "description" : "Name of client sending the request",
+            "example" : "vipps-bapp-client"
+          },
+          "request_id" : {
+            "type" : "string",
+            "description" : "A unique identifier pr. request, used for log correlation",
+            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
+          },
+          "originator_id" : {
+            "type" : "string",
+            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
+            "example" : "9980"
+          },
+          "nnin" : {
+            "type" : "string",
+            "description" : "End user's Norwegian national identification number, string of 11 digits",
+            "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging, will be the same for both codes",
+            "format" : "uuid"
+          },
+          "distribution_method" : {
+            "type" : "string",
+            "description" : "One of the method identifiers returned from selfservice/check_user call"
+          },
+          "locale" : {
+            "type" : "string",
+            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
+            "example" : "en",
+            "enum" : [ "no", "en" ]
+          },
+          "code_words" : {
+            "type" : "string",
+            "description" : "The two code words to distribute"
+          },
+          "exp" : {
+            "type" : "integer",
+            "description" : "Time when code expire, ms since epoch, UTC",
+            "format" : "int64"
+          }
+        },
+        "description" : "Request body content for asking an RA to send code words to an end user"
+      },
+      "PasswordQuarantineResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "pw_reset_timestamp" : {
+            "type" : "integer",
+            "description" : "Time when user's password was last reset, ms since epoch, UTC",
+            "format" : "int64"
+          }
+        },
+        "description" : "Response when quarantining an end user password"
+      },
+      "PasswordQuarantineRequestBodyDTO" : {
+        "type" : "object",
+        "properties" : {
+          "client_name" : {
+            "type" : "string",
+            "description" : "Name of client sending the request",
+            "example" : "vipps-bapp-client"
+          },
+          "request_id" : {
+            "type" : "string",
+            "description" : "A unique identifier pr. request, used for log correlation",
+            "example" : "e6dccaf0-c72f-48d9-9dc8-665e51e08e47"
+          },
+          "originator_id" : {
+            "type" : "string",
+            "description" : "Originator/bank-number for end user's bankID, valid BankID ODS number",
+            "example" : "9980"
+          },
+          "nnin" : {
+            "type" : "string",
+            "description" : "End user's Norwegian national identification number, string of 11 digits",
+            "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging",
+            "format" : "uuid"
+          },
+          "quarantine_until" : {
+            "type" : "integer",
+            "description" : "Time when quarantine expire, ms since epoch, UTC",
+            "format" : "int64"
+          }
+        },
+        "description" : "Request body content for quarantining the user password"
+      },
       "AddBappResponseDTO" : {
         "type" : "object",
         "properties" : {
@@ -1017,17 +1017,6 @@
         },
         "description" : "Minimal body for authenticating and authorizing a request"
       },
-      "DeleteBappResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "status" : {
-            "type" : "string",
-            "description" : "Status value for the delete operation <ul><li>DELETED - BAPP was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "DELETED", "NOT_ENABLED", "BLOCKED_IN_ODS" ]
-          }
-        },
-        "description" : "The result of trying to remove BankID app from an end user's BankID "
-      },
       "StatusBappResponseDTO" : {
         "type" : "object",
         "properties" : {
@@ -1038,6 +1027,17 @@
           }
         },
         "description" : "The result of asking if BankID app is enabled for an end user's BankID"
+      },
+      "DeleteBappResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "string",
+            "description" : "Status value for the delete operation <ul><li>DELETED - BAPP was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "DELETED", "NOT_ENABLED", "BLOCKED_IN_ODS" ]
+          }
+        },
+        "description" : "The result of trying to remove BankID app from an end user's BankID "
       }
     }
   }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2,7 +2,7 @@
   "openapi" : "3.0.1",
   "info" : {
     "title" : "BankID RA Service Provider Interface (SPI) for activation of BankID App",
-    "description" : "Defines the interface to be provided by a Registration Authority service to support activation of BankID App as a HA2 element for an end user's Netcentric BankID.<p>An RA implementing the <i>OTP administration</i> group of operations may offer BankID App to all it's end users having a functioning Netcentric BankID with a code device.</p><p>If in addition, the RA implements the <i>Activation without Code Device</i> groups of operations then end users may activate the Bankid App without having another Code Device at all !</p><h6>This SPI version corresponds to the document 'Specification of Solutions for Activation of BankID App as HA2-elements' version v.62</h6>",
+    "description" : "Defines the interface to be provided by a Registration Authority service to support activation of BankID App as a HA2 element for an end user's Netcentric BankID.<p>An RA implementing the <i>OTP administration</i> group of operations may offer BankID App to all it's end users having a functioning Netcentric BankID with a code device.</p><p>If in addition, the RA implements the <i>Activation without Code Device</i> groups of operations then end users may activate the Bankid App without having another Code Device at all !</p><h6>This SPI version corresponds to the document 'Specification of Solutions for Activation of BankID App as HA2-elements' version v.63</h6>",
     "version" : "1.3-rc1"
   },
   "servers" : [ {
@@ -22,12 +22,12 @@
     "name" : "Activation without Code Device - Self Service"
   } ],
   "paths" : {
-    "/notify_user_of_activation" : {
+    "/remove" : {
       "post" : {
-        "tags" : [ "Activation without Code Device" ],
-        "summary" : "Tell end user that BankID App is activated",
-        "description" : "Request notification of the end user that his BankID App instance is activated",
-        "operationId" : "notifyUserOfActivation",
+        "tags" : [ "OTP administration" ],
+        "summary" : "Removes BankID App from an end user",
+        "description" : "Removes BankID App as an end user's OTP mechanism for at least one of his BankIDs in a given bank",
+        "operationId" : "removeBappOtp",
         "parameters" : [ {
           "name" : "Signature",
           "in" : "header",
@@ -57,19 +57,24 @@
           "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
         } ],
         "requestBody" : {
-          "description" : "Activation code metadata",
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
+                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
               }
             }
-          },
-          "required" : true
+          }
         },
         "responses" : {
           "200" : {
-            "description" : "If all ok, no data is returned"
+            "description" : "If status returned is valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DeleteBappResponseDTO"
+                }
+              }
+            }
           },
           "400" : {
             "description" : "In case of error"
@@ -79,7 +84,163 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/healthcheck" : {
+      "get" : {
+        "tags" : [ "Service availability" ],
+        "summary" : "Health check of the RA application",
+        "description" : "Checks that the RA is capable of handling endpoints declared here",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "RA is healthy"
+          },
+          "500" : {
+            "description" : "RA is not healthy"
+          }
+        }
+      }
+    },
+    "/add" : {
+      "post" : {
+        "tags" : [ "OTP administration" ],
+        "summary" : "Adds BankID App to an end user",
+        "description" : "Adds BankID App to an end user's BankID OTP mechanisms in a given bank",
+        "operationId" : "addBappOtp",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If status returned is valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AddBappResponseDTO"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status" : {
+      "post" : {
+        "tags" : [ "OTP administration" ],
+        "summary" : "Gets the BankID App OTP status for an end user",
+        "description" : "Checks whether an end user has BankID App enabled as an OTP mechanism for at least one of his BankIDs in a given bank",
+        "operationId" : "getBappOtpStatus",
+        "parameters" : [ {
+          "name" : "Signature",
+          "in" : "header",
+          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
+        }, {
+          "name" : "Date",
+          "in" : "header",
+          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
+        }, {
+          "name" : "Digest",
+          "in" : "header",
+          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "If status returned is valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StatusBappResponseDTO"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "In case of error"
+          },
+          "500" : {
+            "description" : "In case of error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
                 }
               }
             }
@@ -361,12 +522,12 @@
         }
       }
     },
-    "/add" : {
+    "/notify_user_of_activation" : {
       "post" : {
-        "tags" : [ "OTP administration" ],
-        "summary" : "Adds BankID App to an end user",
-        "description" : "Adds BankID App to an end user's BankID OTP mechanisms in a given bank",
-        "operationId" : "addBappOtp",
+        "tags" : [ "Activation without Code Device" ],
+        "summary" : "Tell end user that BankID App is activated",
+        "description" : "Request notification of the end user that his BankID App instance is activated",
+        "operationId" : "notifyUserOfActivation",
         "parameters" : [ {
           "name" : "Signature",
           "in" : "header",
@@ -396,24 +557,19 @@
           "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
         } ],
         "requestBody" : {
+          "description" : "Activation code metadata",
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
+                "$ref" : "#/components/schemas/NotifyUserOfActivationRequestBodyDTO"
               }
             }
-          }
+          },
+          "required" : true
         },
         "responses" : {
           "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AddBappResponseDTO"
-                }
-              }
-            }
+            "description" : "If all ok, no data is returned"
           },
           "400" : {
             "description" : "In case of error"
@@ -423,166 +579,10 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
+                  "$ref" : "#/components/schemas/NotifyUserOfActivationErrorResponseDTO"
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/status" : {
-      "post" : {
-        "tags" : [ "OTP administration" ],
-        "summary" : "Gets the BankID App OTP status for an end user",
-        "description" : "Checks whether an end user has BankID App enabled as an OTP mechanism for at least one of his BankIDs in a given bank",
-        "operationId" : "getBappOtpStatus",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/StatusBappResponseDTO"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/remove" : {
-      "post" : {
-        "tags" : [ "OTP administration" ],
-        "summary" : "Removes BankID App from an end user",
-        "description" : "Removes BankID App as an end user's OTP mechanism for at least one of his BankIDs in a given bank",
-        "operationId" : "removeBappOtp",
-        "parameters" : [ {
-          "name" : "Signature",
-          "in" : "header",
-          "description" : "The Signature element, as described in <a href=\"https://tools.ietf.org/html/draft-cavage-http-signatures-12\">Internet-Draft - Signing HTTP Messages</a>.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "keyId=\"fa998090\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"o7zK892....\""
-        }, {
-          "name" : "Date",
-          "in" : "header",
-          "description" : "The date element, required format is the format named 'preferred' specified in <a href=\"https://tools.ietf.org/html/rfc7231#section-7.1.1.1\">RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation tips:</b> Format in Java is 'EEE, dd MMM yyyy HH:mm:ss zzz', locale english.</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "Mon, 16 Sep 2019 12:12:21 GMT"
-        }, {
-          "name" : "Digest",
-          "in" : "header",
-          "description" : "SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance(\"SHA-256\") in Java returns an object which is not thread safe</p>",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AuthenticationBodyDTO"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "If status returned is valid",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/DeleteBappResponseDTO"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "In case of error"
-          },
-          "500" : {
-            "description" : "In case of error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SimpleErrorResponseDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/healthcheck" : {
-      "get" : {
-        "tags" : [ "Service availability" ],
-        "summary" : "Health check of the RA application",
-        "description" : "Checks that the RA is capable of handling endpoints declared here",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "RA is healthy"
-          },
-          "500" : {
-            "description" : "RA is not healthy"
           }
         }
       }
@@ -590,58 +590,27 @@
   },
   "components" : {
     "schemas" : {
-      "NotifyUserOfActivationErrorResponseDTO" : {
+      "DeleteBappResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "string",
+            "description" : "Status value for the delete operation <ul><li>DELETED - BAPP was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "DELETED", "NOT_ENABLED", "BLOCKED_IN_ODS" ]
+          }
+        },
+        "description" : "The result of trying to remove BankID app from an end user's BankID "
+      },
+      "SimpleErrorResponseDTO" : {
         "type" : "object",
         "properties" : {
           "error" : {
             "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "unknown_subject", "internal_error" ]
           }
         },
-        "description" : "The result of asking an ra to notify a user of activation, used in case of some error"
+        "description" : "Result when there is only an error code in return"
       },
-      "ActivationMetadataDTO" : {
-        "type" : "object",
-        "properties" : {
-          "flow" : {
-            "type" : "string",
-            "description" : "The flow used for activation, meanings:<ul><li> - activation_code: A single activation code provided over a secure channel. </li><li> - selfservice: Activation codes provided over two insecure channels. </li><li> - bankid_auth: Activation through a BankID authentication. </li></ul>",
-            "example" : "selfservice",
-            "enum" : [ "activation_code", "selfservice", "bankid_auth" ]
-          },
-          "via_distribution_methods" : {
-            "type" : "array",
-            "description" : "The distribution methods (if any) used during activation.",
-            "items" : {
-              "$ref" : "#/components/schemas/ViaDistributionMethodDTO"
-            }
-          },
-          "locale" : {
-            "type" : "string",
-            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
-            "example" : "en",
-            "enum" : [ "no", "en" ]
-          },
-          "human_readable" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "string",
-              "description" : "Map of localized strings explaining how the device was activated",
-              "example" : "{\"no\":\"med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42\",\"en\":\"using activation codes by email to que***@xyz.no and sms to XXX XX X42\"}"
-            },
-            "description" : "Map of localized strings explaining how the device was activated",
-            "example" : {
-              "no" : "med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42",
-              "en" : "using activation codes by email to que***@xyz.no and sms to XXX XX X42"
-            }
-          }
-        },
-        "description" : "Information about the activation"
-      },
-      "NotifyUserOfActivationRequestBodyDTO" : {
+      "AuthenticationBodyDTO" : {
         "type" : "object",
         "properties" : {
           "client_name" : {
@@ -663,39 +632,31 @@
             "type" : "string",
             "description" : "End user's Norwegian national identification number, string of 11 digits",
             "example" : "11111111016"
-          },
-          "activation_id" : {
-            "type" : "string",
-            "description" : "The id of this activation attempt, used for for logging",
-            "format" : "uuid"
-          },
-          "activation_metadata" : {
-            "$ref" : "#/components/schemas/ActivationMetadataDTO"
           }
         },
-        "description" : "Request body content for asking an RA to send a notification to an end user"
+        "description" : "Minimal body for authenticating and authorizing a request"
       },
-      "ViaDistributionMethodDTO" : {
+      "AddBappResponseDTO" : {
         "type" : "object",
         "properties" : {
-          "type" : {
+          "status" : {
             "type" : "string",
-            "description" : "Type of distribution",
-            "example" : "email",
-            "enum" : [ "sms", "email", "postal" ]
-          },
-          "hint" : {
-            "type" : "string",
-            "description" : "A censored representation of the user's contact information.<ul><li> - type sms: 6 X's followed by two unmasked digits XXX XX X42<li> - type email:  1-3 unmasked characters + \"(...)\" @ domain.topdomain, eg. dei(...)@gmail.com </li><li> - type official_address: No hint, details on the address must not be exposed. </li></ul>",
-            "example" : "dei(...)@gmail.com"
-          },
-          "originator_ref" : {
-            "type" : "string",
-            "description" : "An RA-specific ID which can be used to track the specific distribution method all the way back to the issuing RA.",
-            "example" : "9980@1234-2f44-123456-12"
+            "description" : "Status value for add operation<ul><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "ENABLED", "NOT_ENABLED", "ALREADY_ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
           }
         },
-        "description" : "Details of one distribution method used during activation."
+        "description" : "The result of trying to enable BankID app for an end user's BankID"
+      },
+      "StatusBappResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "string",
+            "description" : "Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
+            "enum" : [ "NOT_ENABLED", "ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
+          }
+        },
+        "description" : "The result of asking if BankID app is enabled for an end user's BankID"
       },
       "DistributionMethodDTO" : {
         "type" : "object",
@@ -772,15 +733,6 @@
           }
         },
         "description" : "The result of querying RA about end user distribution methods"
-      },
-      "SimpleErrorResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "error" : {
-            "type" : "string"
-          }
-        },
-        "description" : "Result when there is only an error code in return"
       },
       "MsisdnDTO" : {
         "type" : "object",
@@ -980,18 +932,58 @@
         },
         "description" : "Request body content for quarantining the user password"
       },
-      "AddBappResponseDTO" : {
+      "NotifyUserOfActivationErrorResponseDTO" : {
         "type" : "object",
         "properties" : {
+          "error" : {
+            "type" : "string"
+          },
           "status" : {
             "type" : "string",
-            "description" : "Status value for add operation<ul><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "ENABLED", "NOT_ENABLED", "ALREADY_ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
+            "enum" : [ "unknown_subject", "internal_error" ]
           }
         },
-        "description" : "The result of trying to enable BankID app for an end user's BankID"
+        "description" : "The result of asking an ra to notify a user of activation, used in case of some error"
       },
-      "AuthenticationBodyDTO" : {
+      "ActivationMetadataDTO" : {
+        "type" : "object",
+        "properties" : {
+          "flow" : {
+            "type" : "string",
+            "description" : "The flow used for activation, meanings:<ul><li> - activation_code: A single activation code provided over a secure channel. </li><li> - selfservice: Activation codes provided over two insecure channels. </li><li> - bankid_auth: Activation through a BankID authentication. </li></ul>",
+            "example" : "selfservice",
+            "enum" : [ "activation_code", "selfservice", "bankid_auth" ]
+          },
+          "via_distribution_methods" : {
+            "type" : "array",
+            "description" : "The distribution methods (if any) used during activation.",
+            "items" : {
+              "$ref" : "#/components/schemas/ViaDistributionMethodDTO"
+            }
+          },
+          "locale" : {
+            "type" : "string",
+            "description" : "Locale of initiating app, either \"no\" for Norwegian and Norwegian dialects, otherwise \"en\"<h5>(the 'no' value is shown as 'false', openapi nuisance)</h5>",
+            "example" : "en",
+            "enum" : [ "no", "en" ]
+          },
+          "human_readable" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "description" : "Map of localized strings explaining how the device was activated",
+              "example" : "{\"no\":\"med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42\",\"en\":\"using activation codes by email to que***@xyz.no and sms to XXX XX X42\"}"
+            },
+            "description" : "Map of localized strings explaining how the device was activated",
+            "example" : {
+              "no" : "med aktiveringskoder gitt på email til que***@xyz.no og på sms til XXX XX X42",
+              "en" : "using activation codes by email to que***@xyz.no and sms to XXX XX X42"
+            }
+          }
+        },
+        "description" : "Information about the activation"
+      },
+      "NotifyUserOfActivationRequestBodyDTO" : {
         "type" : "object",
         "properties" : {
           "client_name" : {
@@ -1013,31 +1005,39 @@
             "type" : "string",
             "description" : "End user's Norwegian national identification number, string of 11 digits",
             "example" : "11111111016"
+          },
+          "activation_id" : {
+            "type" : "string",
+            "description" : "The id of this activation attempt, used for for logging",
+            "format" : "uuid"
+          },
+          "activation_metadata" : {
+            "$ref" : "#/components/schemas/ActivationMetadataDTO"
           }
         },
-        "description" : "Minimal body for authenticating and authorizing a request"
+        "description" : "Request body content for asking an RA to send a notification to an end user"
       },
-      "StatusBappResponseDTO" : {
+      "ViaDistributionMethodDTO" : {
         "type" : "object",
         "properties" : {
-          "status" : {
+          "type" : {
             "type" : "string",
-            "description" : "Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected to the BankID, but was blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "NOT_ENABLED", "ENABLED", "NOT_AVAILABLE", "BANK_ID_NOT_AVAILABLE", "BLOCKED_BY_BANK", "BLOCKED_IN_ODS" ]
+            "description" : "Type of distribution",
+            "example" : "email",
+            "enum" : [ "sms", "email", "postal" ]
+          },
+          "hint" : {
+            "type" : "string",
+            "description" : "A censored representation of the user's contact information.<ul><li> - type sms: 6 X's followed by two unmasked digits XXX XX X42<li> - type email:  1-3 unmasked characters + \"(...)\" @ domain.topdomain, eg. dei(...)@gmail.com </li><li> - type official_address: No hint, details on the address must not be exposed. </li></ul>",
+            "example" : "dei(...)@gmail.com"
+          },
+          "originator_ref" : {
+            "type" : "string",
+            "description" : "An RA-specific ID which can be used to track the specific distribution method all the way back to the issuing RA.",
+            "example" : "9980@1234-2f44-123456-12"
           }
         },
-        "description" : "The result of asking if BankID app is enabled for an end user's BankID"
-      },
-      "DeleteBappResponseDTO" : {
-        "type" : "object",
-        "properties" : {
-          "status" : {
-            "type" : "string",
-            "description" : "Status value for the delete operation <ul><li>DELETED - BAPP was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>",
-            "enum" : [ "DELETED", "NOT_ENABLED", "BLOCKED_IN_ODS" ]
-          }
-        },
-        "description" : "The result of trying to remove BankID app from an end user's BankID "
+        "description" : "Details of one distribution method used during activation."
       }
     }
   }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -9,7 +9,7 @@ info:
     without Code Device</i> groups of operations then end users may activate the Bankid
     App without having another Code Device at all !</p><h6>This SPI version corresponds
     to the document 'Specification of Solutions for Activation of BankID App as HA2-elements'
-    version v.62</h6>
+    version v.63</h6>
   version: 1.3-rc1
 servers:
 - url: https://ra-preprod.bankidnorge.no/api/enduser/bankid/netcentric/vipps/bapp
@@ -23,14 +23,14 @@ tags:
 - name: Activation without Code Device
 - name: Activation without Code Device - Self Service
 paths:
-  /notify_user_of_activation:
+  /remove:
     post:
       tags:
-      - Activation without Code Device
-      summary: Tell end user that BankID App is activated
-      description: Request notification of the end user that his BankID App instance
-        is activated
-      operationId: notifyUserOfActivation
+      - OTP administration
+      summary: Removes BankID App from an end user
+      description: Removes BankID App as an end user's OTP mechanism for at least
+        one of his BankIDs in a given bank
+      operationId: removeBappOtp
       parameters:
       - name: Signature
         in: header
@@ -60,15 +60,17 @@ paths:
           type: string
         example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
       requestBody:
-        description: Activation code metadata
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
-        required: true
+              $ref: '#/components/schemas/AuthenticationBodyDTO'
       responses:
         200:
-          description: If all ok, no data is returned
+          description: If status returned is valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteBappResponseDTO'
         400:
           description: In case of error
         500:
@@ -76,7 +78,131 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /healthcheck:
+    get:
+      tags:
+      - Service availability
+      summary: Health check of the RA application
+      description: Checks that the RA is capable of handling endpoints declared here
+      operationId: healthCheck
+      responses:
+        200:
+          description: RA is healthy
+        500:
+          description: RA is not healthy
+  /add:
+    post:
+      tags:
+      - OTP administration
+      summary: Adds BankID App to an end user
+      description: Adds BankID App to an end user's BankID OTP mechanisms in a given
+        bank
+      operationId: addBappOtp
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationBodyDTO'
+      responses:
+        200:
+          description: If status returned is valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddBappResponseDTO'
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /status:
+    post:
+      tags:
+      - OTP administration
+      summary: Gets the BankID App OTP status for an end user
+      description: Checks whether an end user has BankID App enabled as an OTP mechanism
+        for at least one of his BankIDs in a given bank
+      operationId: getBappOtpStatus
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationBodyDTO'
+      responses:
+        200:
+          description: If status returned is valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusBappResponseDTO'
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
   /selfservice/check_user:
     post:
       tags:
@@ -308,14 +434,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /add:
+  /notify_user_of_activation:
     post:
       tags:
-      - OTP administration
-      summary: Adds BankID App to an end user
-      description: Adds BankID App to an end user's BankID OTP mechanisms in a given
-        bank
-      operationId: addBappOtp
+      - Activation without Code Device
+      summary: Tell end user that BankID App is activated
+      description: Request notification of the end user that his BankID App instance
+        is activated
+      operationId: notifyUserOfActivation
       parameters:
       - name: Signature
         in: header
@@ -345,17 +471,15 @@ paths:
           type: string
         example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
       requestBody:
+        description: Activation code metadata
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthenticationBodyDTO'
+              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
+        required: true
       responses:
         200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AddBappResponseDTO'
+          description: If all ok, no data is returned
         400:
           description: In case of error
         500:
@@ -363,189 +487,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /status:
-    post:
-      tags:
-      - OTP administration
-      summary: Gets the BankID App OTP status for an end user
-      description: Checks whether an end user has BankID App enabled as an OTP mechanism
-        for at least one of his BankIDs in a given bank
-      operationId: getBappOtpStatus
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationBodyDTO'
-      responses:
-        200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StatusBappResponseDTO'
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /remove:
-    post:
-      tags:
-      - OTP administration
-      summary: Removes BankID App from an end user
-      description: Removes BankID App as an end user's OTP mechanism for at least
-        one of his BankIDs in a given bank
-      operationId: removeBappOtp
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationBodyDTO'
-      responses:
-        200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteBappResponseDTO'
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /healthcheck:
-    get:
-      tags:
-      - Service availability
-      summary: Health check of the RA application
-      description: Checks that the RA is capable of handling endpoints declared here
-      operationId: healthCheck
-      responses:
-        200:
-          description: RA is healthy
-        500:
-          description: RA is not healthy
+                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
 components:
   schemas:
-    NotifyUserOfActivationErrorResponseDTO:
+    DeleteBappResponseDTO:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Status value for the delete operation <ul><li>DELETED - BAPP
+            was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled
+            for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't
+            deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>
+          enum:
+          - DELETED
+          - NOT_ENABLED
+          - BLOCKED_IN_ODS
+      description: 'The result of trying to remove BankID app from an end user''s
+        BankID '
+    SimpleErrorResponseDTO:
       type: object
       properties:
         error:
           type: string
-        status:
-          type: string
-          enum:
-          - unknown_subject
-          - internal_error
-      description: The result of asking an ra to notify a user of activation, used
-        in case of some error
-    ActivationMetadataDTO:
-      type: object
-      properties:
-        flow:
-          type: string
-          description: 'The flow used for activation, meanings:<ul><li> - activation_code:
-            A single activation code provided over a secure channel. </li><li> - selfservice:
-            Activation codes provided over two insecure channels. </li><li> - bankid_auth:
-            Activation through a BankID authentication. </li></ul>'
-          example: selfservice
-          enum:
-          - activation_code
-          - selfservice
-          - bankid_auth
-        via_distribution_methods:
-          type: array
-          description: The distribution methods (if any) used during activation.
-          items:
-            $ref: '#/components/schemas/ViaDistributionMethodDTO'
-        locale:
-          type: string
-          description: Locale of initiating app, either "no" for Norwegian and Norwegian
-            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
-            nuisance)</h5>
-          example: en
-          enum:
-          - no
-          - en
-        human_readable:
-          type: object
-          additionalProperties:
-            type: string
-            description: Map of localized strings explaining how the device was activated
-            example: '{"no":"med aktiveringskoder gitt på email til que***@xyz.no
-              og på sms til XXX XX X42","en":"using activation codes by email to que***@xyz.no
-              and sms to XXX XX X42"}'
-          description: Map of localized strings explaining how the device was activated
-          example:
-            no: med aktiveringskoder gitt på email til que***@xyz.no og på sms til
-              XXX XX X42
-            en: using activation codes by email to que***@xyz.no and sms to XXX XX
-              X42
-      description: Information about the activation
-    NotifyUserOfActivationRequestBodyDTO:
+      description: Result when there is only an error code in return
+    AuthenticationBodyDTO:
       type: object
       properties:
         client_name:
@@ -566,39 +532,48 @@ components:
           description: End user's Norwegian national identification number, string
             of 11 digits
           example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging
-          format: uuid
-        activation_metadata:
-          $ref: '#/components/schemas/ActivationMetadataDTO'
-      description: Request body content for asking an RA to send a notification to
-        an end user
-    ViaDistributionMethodDTO:
+      description: Minimal body for authenticating and authorizing a request
+    AddBappResponseDTO:
       type: object
       properties:
-        type:
+        status:
           type: string
-          description: Type of distribution
-          example: email
+          description: Status value for add operation<ul><li>ENABLED - BAPP is enabled
+            for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED
+            - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available
+            for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active
+            BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS
+            - BAPP is connected to the BankID, but was blocked by ODS because of wrong
+            attempts</li></ul>
           enum:
-          - sms
-          - email
-          - postal
-        hint:
+          - ENABLED
+          - NOT_ENABLED
+          - ALREADY_ENABLED
+          - NOT_AVAILABLE
+          - BANK_ID_NOT_AVAILABLE
+          - BLOCKED_BY_BANK
+          - BLOCKED_IN_ODS
+      description: The result of trying to enable BankID app for an end user's BankID
+    StatusBappResponseDTO:
+      type: object
+      properties:
+        status:
           type: string
-          description: 'A censored representation of the user''s contact information.<ul><li>
-            - type sms: 6 X''s followed by two unmasked digits XXX XX X42<li> - type
-            email:  1-3 unmasked characters + "(...)" @ domain.topdomain, eg. dei(...)@gmail.com
-            </li><li> - type official_address: No hint, details on the address must
-            not be exposed. </li></ul>'
-          example: dei(...)@gmail.com
-        originator_ref:
-          type: string
-          description: An RA-specific ID which can be used to track the specific distribution
-            method all the way back to the issuing RA.
-          example: 9980@1234-2f44-123456-12
-      description: Details of one distribution method used during activation.
+          description: Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP
+            is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the
+            end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE
+            - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user
+            is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected
+            to the BankID, but was blocked by ODS because of wrong attempts</li></ul>
+          enum:
+          - NOT_ENABLED
+          - ENABLED
+          - NOT_AVAILABLE
+          - BANK_ID_NOT_AVAILABLE
+          - BLOCKED_BY_BANK
+          - BLOCKED_IN_ODS
+      description: The result of asking if BankID app is enabled for an end user's
+        BankID
     DistributionMethodDTO:
       type: object
       properties:
@@ -679,12 +654,6 @@ components:
           - BLOCKED_BY_BANK
           - BLOCKED_IN_ODS
       description: The result of querying RA about end user distribution methods
-    SimpleErrorResponseDTO:
-      type: object
-      properties:
-        error:
-          type: string
-      description: Result when there is only an error code in return
     MsisdnDTO:
       type: object
       properties:
@@ -862,28 +831,62 @@ components:
           description: Time when quarantine expire, ms since epoch, UTC
           format: int64
       description: Request body content for quarantining the user password
-    AddBappResponseDTO:
+    NotifyUserOfActivationErrorResponseDTO:
       type: object
       properties:
+        error:
+          type: string
         status:
           type: string
-          description: Status value for add operation<ul><li>ENABLED - BAPP is enabled
-            for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED
-            - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available
-            for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active
-            BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS
-            - BAPP is connected to the BankID, but was blocked by ODS because of wrong
-            attempts</li></ul>
           enum:
-          - ENABLED
-          - NOT_ENABLED
-          - ALREADY_ENABLED
-          - NOT_AVAILABLE
-          - BANK_ID_NOT_AVAILABLE
-          - BLOCKED_BY_BANK
-          - BLOCKED_IN_ODS
-      description: The result of trying to enable BankID app for an end user's BankID
-    AuthenticationBodyDTO:
+          - unknown_subject
+          - internal_error
+      description: The result of asking an ra to notify a user of activation, used
+        in case of some error
+    ActivationMetadataDTO:
+      type: object
+      properties:
+        flow:
+          type: string
+          description: 'The flow used for activation, meanings:<ul><li> - activation_code:
+            A single activation code provided over a secure channel. </li><li> - selfservice:
+            Activation codes provided over two insecure channels. </li><li> - bankid_auth:
+            Activation through a BankID authentication. </li></ul>'
+          example: selfservice
+          enum:
+          - activation_code
+          - selfservice
+          - bankid_auth
+        via_distribution_methods:
+          type: array
+          description: The distribution methods (if any) used during activation.
+          items:
+            $ref: '#/components/schemas/ViaDistributionMethodDTO'
+        locale:
+          type: string
+          description: Locale of initiating app, either "no" for Norwegian and Norwegian
+            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
+            nuisance)</h5>
+          example: en
+          enum:
+          - no
+          - en
+        human_readable:
+          type: object
+          additionalProperties:
+            type: string
+            description: Map of localized strings explaining how the device was activated
+            example: '{"no":"med aktiveringskoder gitt på email til que***@xyz.no
+              og på sms til XXX XX X42","en":"using activation codes by email to que***@xyz.no
+              and sms to XXX XX X42"}'
+          description: Map of localized strings explaining how the device was activated
+          example:
+            no: med aktiveringskoder gitt på email til que***@xyz.no og på sms til
+              XXX XX X42
+            en: using activation codes by email to que***@xyz.no and sms to XXX XX
+              X42
+      description: Information about the activation
+    NotifyUserOfActivationRequestBodyDTO:
       type: object
       properties:
         client_name:
@@ -904,39 +907,36 @@ components:
           description: End user's Norwegian national identification number, string
             of 11 digits
           example: "11111111016"
-      description: Minimal body for authenticating and authorizing a request
-    StatusBappResponseDTO:
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging
+          format: uuid
+        activation_metadata:
+          $ref: '#/components/schemas/ActivationMetadataDTO'
+      description: Request body content for asking an RA to send a notification to
+        an end user
+    ViaDistributionMethodDTO:
       type: object
       properties:
-        status:
+        type:
           type: string
-          description: Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP
-            is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the
-            end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE
-            - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user
-            is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected
-            to the BankID, but was blocked by ODS because of wrong attempts</li></ul>
+          description: Type of distribution
+          example: email
           enum:
-          - NOT_ENABLED
-          - ENABLED
-          - NOT_AVAILABLE
-          - BANK_ID_NOT_AVAILABLE
-          - BLOCKED_BY_BANK
-          - BLOCKED_IN_ODS
-      description: The result of asking if BankID app is enabled for an end user's
-        BankID
-    DeleteBappResponseDTO:
-      type: object
-      properties:
-        status:
+          - sms
+          - email
+          - postal
+        hint:
           type: string
-          description: Status value for the delete operation <ul><li>DELETED - BAPP
-            was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled
-            for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't
-            deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>
-          enum:
-          - DELETED
-          - NOT_ENABLED
-          - BLOCKED_IN_ODS
-      description: 'The result of trying to remove BankID app from an end user''s
-        BankID '
+          description: 'A censored representation of the user''s contact information.<ul><li>
+            - type sms: 6 X''s followed by two unmasked digits XXX XX X42<li> - type
+            email:  1-3 unmasked characters + "(...)" @ domain.topdomain, eg. dei(...)@gmail.com
+            </li><li> - type official_address: No hint, details on the address must
+            not be exposed. </li></ul>'
+          example: dei(...)@gmail.com
+        originator_ref:
+          type: string
+          description: An RA-specific ID which can be used to track the specific distribution
+            method all the way back to the issuing RA.
+          example: 9980@1234-2f44-123456-12
+      description: Details of one distribution method used during activation.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10,7 +10,7 @@ info:
     App without having another Code Device at all !</p><h6>This SPI version corresponds
     to the document 'Specification of Solutions for Activation of BankID App as HA2-elements'
     version v.62</h6>
-  version: "1.3"
+  version: 1.3-rc1
 servers:
 - url: https://ra-preprod.bankidnorge.no/api/enduser/bankid/netcentric/vipps/bapp
   description: Preprod Ra-lite
@@ -23,60 +23,6 @@ tags:
 - name: Activation without Code Device
 - name: Activation without Code Device - Self Service
 paths:
-  /notify_user_of_activation:
-    post:
-      tags:
-      - Activation without Code Device
-      summary: Tell end user that BankID App is activated
-      description: Request notification of the end user that his BankID App instance
-        is activated
-      operationId: notifyUserOfActivation
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        description: Activation code metadata
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
-        required: true
-      responses:
-        200:
-          description: If all ok, no data is returned
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
   /selfservice/send_verification_code:
     post:
       tags:
@@ -193,6 +139,115 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /notify_user_of_activation:
+    post:
+      tags:
+      - Activation without Code Device
+      summary: Tell end user that BankID App is activated
+      description: Request notification of the end user that his BankID App instance
+        is activated
+      operationId: notifyUserOfActivation
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        description: Activation code metadata
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
+        required: true
+      responses:
+        200:
+          description: If all ok, no data is returned
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
+  /selfservice/send_code_words:
+    post:
+      tags:
+      - Activation without Code Device - Self Service
+      summary: Send codewords to an end user
+      description: request distribution of code words to be sent to a user. Upon receiving
+        a request on this end-point, the RA should distribute the provided code through
+        the channel indicated, or return an error-code.
+      operationId: selfServiceSendCodeWords
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        description: Activation codes and how to distribute
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendCodeWordsRequestBodyDTO'
+        required: true
+      responses:
+        200:
+          description: If all ok, no data is returned
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
   /selfservice/check_user:
     post:
       tags:
@@ -253,129 +308,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /selfservice/send_code_words:
-    post:
-      tags:
-      - Activation without Code Device - Self Service
-      summary: Send codewords to an end user
-      description: request distribution of code words to be sent to a user. Upon receiving
-        a request on this end-point, the RA should distribute the provided code through
-        the channel indicated, or return an error-code.
-      operationId: selfServiceSendCodeWords
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        description: Activation codes and how to distribute
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SendCodeWordsRequestBodyDTO'
-        required: true
-      responses:
-        200:
-          description: If all ok, no data is returned
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /status:
-    post:
-      tags:
-      - OTP administration
-      summary: Gets the BankID App OTP status for an end user
-      description: Checks whether an end user has BankID App enabled as an OTP mechanism
-        for at least one of his BankIDs in a given bank
-      operationId: getBappOtpStatus
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationBodyDTO'
-      responses:
-        200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StatusBappResponseDTO'
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /healthcheck:
-    get:
-      tags:
-      - Service availability
-      summary: Health check of the RA application
-      description: Checks that the RA is capable of handling endpoints declared here
-      operationId: healthCheck
-      responses:
-        200:
-          description: RA is healthy
-        500:
-          description: RA is not healthy
   /add:
     post:
       tags:
@@ -488,117 +420,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /status:
+    post:
+      tags:
+      - OTP administration
+      summary: Gets the BankID App OTP status for an end user
+      description: Checks whether an end user has BankID App enabled as an OTP mechanism
+        for at least one of his BankIDs in a given bank
+      operationId: getBappOtpStatus
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationBodyDTO'
+      responses:
+        200:
+          description: If status returned is valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusBappResponseDTO'
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /healthcheck:
+    get:
+      tags:
+      - Service availability
+      summary: Health check of the RA application
+      description: Checks that the RA is capable of handling endpoints declared here
+      operationId: healthCheck
+      responses:
+        200:
+          description: RA is healthy
+        500:
+          description: RA is not healthy
 components:
   schemas:
-    NotifyUserOfActivationErrorResponseDTO:
-      type: object
-      properties:
-        error:
-          type: string
-        status:
-          type: string
-          enum:
-          - unknown_subject
-          - internal_error
-      description: The result of asking an ra to notify a user of activation, used
-        in case of some error
-    ActivationMetadataDTO:
-      type: object
-      properties:
-        flow:
-          type: string
-          description: 'The flow used for activation, meanings:<ul><li> - activation_code:
-            A single activation code provided over a secure channel. </li><li> - selfservice:
-            Activation codes provided over two insecure channels. </li><li> - bankid_auth:
-            Activation through a BankID authentication. </li></ul>'
-          example: selfservice
-          enum:
-          - activation_code
-          - selfservice
-          - bankid_auth
-        via_distribution_methods:
-          type: array
-          description: The distribution methods (if any) used during activation.
-          items:
-            $ref: '#/components/schemas/ViaDistributionMethodDTO'
-        locale:
-          type: string
-          description: Locale of initiating app, either "no" for Norwegian and Norwegian
-            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
-            nuisance)</h5>
-          example: en
-          enum:
-          - no
-          - en
-        human_readable:
-          type: object
-          additionalProperties:
-            type: string
-            description: Map of localized strings explaining how the device was activated
-            example: '{"no":"med aktiveringskoder gitt på email til que***@xyz.no
-              og på sms til XXX XX X42","en":"using activation codes by email to que***@xyz.no
-              and sms to XXX XX X42"}'
-          description: Map of localized strings explaining how the device was activated
-          example:
-            no: med aktiveringskoder gitt på email til que***@xyz.no og på sms til
-              XXX XX X42
-            en: using activation codes by email to que***@xyz.no and sms to XXX XX
-              X42
-      description: Information about the activation
-    NotifyUserOfActivationRequestBodyDTO:
-      type: object
-      properties:
-        client_name:
-          type: string
-          description: Name of client sending the request
-          example: vipps-bapp-client
-        request_id:
-          type: string
-          description: A unique identifier pr. request, used for log correlation
-          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
-        originator_id:
-          type: string
-          description: Originator/bank-number for end user's bankID, valid BankID
-            ODS number
-          example: "9980"
-        nnin:
-          type: string
-          description: End user's Norwegian national identification number, string
-            of 11 digits
-          example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging
-          format: uuid
-        activationMetadata:
-          $ref: '#/components/schemas/ActivationMetadataDTO'
-      description: Request body content for asking an RA to send a notification to
-        an end user
-    ViaDistributionMethodDTO:
-      type: object
-      properties:
-        type:
-          type: string
-          description: Type of distribution
-          example: email
-          enum:
-          - sms
-          - email
-          - postal
-        hint:
-          type: string
-          description: 'A censored representation of the user''s contact information.<ul><li>
-            - type sms: 6 X''s followed by two unmasked digits XXX XX X42<li> - type
-            email:  1-3 unmasked characters + "(...)" @ domain.topdomain, eg. dei(...)@gmail.com
-            </li><li> - type official_address: No hint, details on the address must
-            not be exposed. </li></ul>'
-          example: dei(...)@gmail.com
-        originator_ref:
-          type: string
-          description: An RA-specific ID which can be used to track the specific distribution
-            method all the way back to the issuing RA.
-          example: 9980@1234-2f44-123456-12
-      description: Details of one distribution method used during activation.
     SimpleErrorResponseDTO:
       type: object
       properties:
@@ -691,6 +582,163 @@ components:
           description: Time when quarantine expire, ms since epoch, UTC
           format: int64
       description: Request body content for quarantining the user password
+    NotifyUserOfActivationErrorResponseDTO:
+      type: object
+      properties:
+        error:
+          type: string
+        status:
+          type: string
+          enum:
+          - unknown_subject
+          - internal_error
+      description: The result of asking an ra to notify a user of activation, used
+        in case of some error
+    ActivationMetadataDTO:
+      type: object
+      properties:
+        flow:
+          type: string
+          description: 'The flow used for activation, meanings:<ul><li> - activation_code:
+            A single activation code provided over a secure channel. </li><li> - selfservice:
+            Activation codes provided over two insecure channels. </li><li> - bankid_auth:
+            Activation through a BankID authentication. </li></ul>'
+          example: selfservice
+          enum:
+          - activation_code
+          - selfservice
+          - bankid_auth
+        via_distribution_methods:
+          type: array
+          description: The distribution methods (if any) used during activation.
+          items:
+            $ref: '#/components/schemas/ViaDistributionMethodDTO'
+        locale:
+          type: string
+          description: Locale of initiating app, either "no" for Norwegian and Norwegian
+            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
+            nuisance)</h5>
+          example: en
+          enum:
+          - no
+          - en
+        human_readable:
+          type: object
+          additionalProperties:
+            type: string
+            description: Map of localized strings explaining how the device was activated
+            example: '{"no":"med aktiveringskoder gitt på email til que***@xyz.no
+              og på sms til XXX XX X42","en":"using activation codes by email to que***@xyz.no
+              and sms to XXX XX X42"}'
+          description: Map of localized strings explaining how the device was activated
+          example:
+            no: med aktiveringskoder gitt på email til que***@xyz.no og på sms til
+              XXX XX X42
+            en: using activation codes by email to que***@xyz.no and sms to XXX XX
+              X42
+      description: Information about the activation
+    NotifyUserOfActivationRequestBodyDTO:
+      type: object
+      properties:
+        client_name:
+          type: string
+          description: Name of client sending the request
+          example: vipps-bapp-client
+        request_id:
+          type: string
+          description: A unique identifier pr. request, used for log correlation
+          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
+        originator_id:
+          type: string
+          description: Originator/bank-number for end user's bankID, valid BankID
+            ODS number
+          example: "9980"
+        nnin:
+          type: string
+          description: End user's Norwegian national identification number, string
+            of 11 digits
+          example: "11111111016"
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging
+          format: uuid
+        activation_metadata:
+          $ref: '#/components/schemas/ActivationMetadataDTO'
+      description: Request body content for asking an RA to send a notification to
+        an end user
+    ViaDistributionMethodDTO:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of distribution
+          example: email
+          enum:
+          - sms
+          - email
+          - postal
+        hint:
+          type: string
+          description: 'A censored representation of the user''s contact information.<ul><li>
+            - type sms: 6 X''s followed by two unmasked digits XXX XX X42<li> - type
+            email:  1-3 unmasked characters + "(...)" @ domain.topdomain, eg. dei(...)@gmail.com
+            </li><li> - type official_address: No hint, details on the address must
+            not be exposed. </li></ul>'
+          example: dei(...)@gmail.com
+        originator_ref:
+          type: string
+          description: An RA-specific ID which can be used to track the specific distribution
+            method all the way back to the issuing RA.
+          example: 9980@1234-2f44-123456-12
+      description: Details of one distribution method used during activation.
+    SendCodeWordsRequestBodyDTO:
+      type: object
+      properties:
+        client_name:
+          type: string
+          description: Name of client sending the request
+          example: vipps-bapp-client
+        request_id:
+          type: string
+          description: A unique identifier pr. request, used for log correlation
+          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
+        originator_id:
+          type: string
+          description: Originator/bank-number for end user's bankID, valid BankID
+            ODS number
+          example: "9980"
+        nnin:
+          type: string
+          description: End user's Norwegian national identification number, string
+            of 11 digits
+          example: "11111111016"
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging, will
+            be the same for both codes
+          format: uuid
+        distribution_method:
+          type: string
+          description: One of the method identifiers returned from selfservice/check_user
+            call
+        locale:
+          type: string
+          description: Locale of initiating app, either "no" for Norwegian and Norwegian
+            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
+            nuisance)</h5>
+          example: en
+          enum:
+          - no
+          - en
+        code_words:
+          type: string
+          description: The two code words to distribute
+        exp:
+          type: integer
+          description: Time when code expire, ms since epoch, UTC
+          format: int64
+      description: Request body content for asking an RA to send code words to an
+        end user
     DistributionMethodDTO:
       type: object
       properties:
@@ -755,6 +803,21 @@ components:
           description: List of distribution methods
           items:
             $ref: '#/components/schemas/DistributionMethodDTO'
+        status:
+          type: string
+          description: Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP
+            is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the
+            end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE
+            - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user
+            is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected
+            to the BankID, but was blocked by ODS because of wrong attempts</li></ul>
+          enum:
+          - NOT_ENABLED
+          - ENABLED
+          - NOT_AVAILABLE
+          - BANK_ID_NOT_AVAILABLE
+          - BLOCKED_BY_BANK
+          - BLOCKED_IN_ODS
       description: The result of querying RA about end user distribution methods
     MsisdnDTO:
       type: object
@@ -799,74 +862,27 @@ components:
           $ref: '#/components/schemas/MsisdnDTO'
       description: Request body content for asking an RA about end user distribution
         methods
-    SendCodeWordsRequestBodyDTO:
-      type: object
-      properties:
-        client_name:
-          type: string
-          description: Name of client sending the request
-          example: vipps-bapp-client
-        request_id:
-          type: string
-          description: A unique identifier pr. request, used for log correlation
-          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
-        originator_id:
-          type: string
-          description: Originator/bank-number for end user's bankID, valid BankID
-            ODS number
-          example: "9980"
-        nnin:
-          type: string
-          description: End user's Norwegian national identification number, string
-            of 11 digits
-          example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging, will
-            be the same for both codes
-          format: uuid
-        distribution_method:
-          type: string
-          description: One of the method identifiers returned from selfservice/check_user
-            call
-        locale:
-          type: string
-          description: Locale of initiating app, either "no" for Norwegian and Norwegian
-            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
-            nuisance)</h5>
-          example: en
-          enum:
-          - no
-          - en
-        code_words:
-          type: string
-          description: The two code words to distribute
-        exp:
-          type: integer
-          description: Time when code expire, ms since epoch, UTC
-          format: int64
-      description: Request body content for asking an RA to send code words to an
-        end user
-    StatusBappResponseDTO:
+    AddBappResponseDTO:
       type: object
       properties:
         status:
           type: string
-          description: Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP
-            is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the
-            end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE
-            - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user
-            is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected
-            to the BankID, but was blocked by ODS because of wrong attempts</li></ul>
+          description: Status value for add operation<ul><li>ENABLED - BAPP is enabled
+            for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED
+            - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available
+            for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active
+            BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS
+            - BAPP is connected to the BankID, but was blocked by ODS because of wrong
+            attempts</li></ul>
           enum:
-          - NOT_ENABLED
           - ENABLED
+          - NOT_ENABLED
+          - ALREADY_ENABLED
           - NOT_AVAILABLE
           - BANK_ID_NOT_AVAILABLE
           - BLOCKED_BY_BANK
           - BLOCKED_IN_ODS
-      description: The result of asking if BankID app is enabled for an end user's
-        BankID
+      description: The result of trying to enable BankID app for an end user's BankID
     AuthenticationBodyDTO:
       type: object
       properties:
@@ -889,27 +905,6 @@ components:
             of 11 digits
           example: "11111111016"
       description: Minimal body for authenticating and authorizing a request
-    AddBappResponseDTO:
-      type: object
-      properties:
-        status:
-          type: string
-          description: Status value for add operation<ul><li>ENABLED - BAPP is enabled
-            for the end user</li><li>NOT_ENABLED - Failed to enable BAPP for the customer</li><li>ALREADY_ENABLED
-            - BAPP was already enabled</li><li>NOT_AVAILABLE - BAPP is not available
-            for the bank</li><li>BANK_ID_NOT_AVAILABLE - end user doesn't have active
-            BankID</li><li>BLOCKED_BY_BANK - end user is not allowed to use BAPP</li><li>BLOCKED_IN_ODS
-            - BAPP is connected to the BankID, but was blocked by ODS because of wrong
-            attempts</li></ul>
-          enum:
-          - ENABLED
-          - NOT_ENABLED
-          - ALREADY_ENABLED
-          - NOT_AVAILABLE
-          - BANK_ID_NOT_AVAILABLE
-          - BLOCKED_BY_BANK
-          - BLOCKED_IN_ODS
-      description: The result of trying to enable BankID app for an end user's BankID
     DeleteBappResponseDTO:
       type: object
       properties:
@@ -925,3 +920,23 @@ components:
           - BLOCKED_IN_ODS
       description: 'The result of trying to remove BankID app from an end user''s
         BankID '
+    StatusBappResponseDTO:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Status value for end user's BAPP <ul><li>NOT_ENABLED - BAPP
+            is not enabled, but could be</li><li>ENABLED - BAPP is enabled for the
+            end user</li><li>NOT_AVAILABLE - BAPP is not available for the bank</li><li>BANK_ID_NOT_AVAILABLE
+            - end user doesn't have active BankID</li><li>BLOCKED_BY_BANK - end user
+            is not allowed to use BAPP</li><li>BLOCKED_IN_ODS - BAPP is connected
+            to the BankID, but was blocked by ODS because of wrong attempts</li></ul>
+          enum:
+          - NOT_ENABLED
+          - ENABLED
+          - NOT_AVAILABLE
+          - BANK_ID_NOT_AVAILABLE
+          - BLOCKED_BY_BANK
+          - BLOCKED_IN_ODS
+      description: The result of asking if BankID app is enabled for an end user's
+        BankID

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -23,6 +23,120 @@ tags:
 - name: Activation without Code Device
 - name: Activation without Code Device - Self Service
 paths:
+  /notify_user_of_activation:
+    post:
+      tags:
+      - Activation without Code Device
+      summary: Tell end user that BankID App is activated
+      description: Request notification of the end user that his BankID App instance
+        is activated
+      operationId: notifyUserOfActivation
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        description: Activation code metadata
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
+        required: true
+      responses:
+        200:
+          description: If all ok, no data is returned
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
+  /selfservice/check_user:
+    post:
+      tags:
+      - Activation without Code Device - Self Service
+      summary: Check two-channel options for end user
+      description: <p>Endpoint to check if a specific user is eligible from single
+        originator for self-service activation.</p><p>The RA should check if the provided
+        phone number is registered for the user, but return the other information
+        regardless.
+      operationId: selfServiceCheckUser
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        description: Activation code and how to distribute
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelfServiceCheckUserRequestBodyDTO'
+        required: true
+      responses:
+        200:
+          description: If status returned is valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SelfServiceCheckUserResponseDTO'
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
   /selfservice/send_verification_code:
     post:
       tags:
@@ -68,6 +182,61 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SendVerificationCodeRequestBodyDTO'
+        required: true
+      responses:
+        200:
+          description: If all ok, no data is returned
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /selfservice/send_code_words:
+    post:
+      tags:
+      - Activation without Code Device - Self Service
+      summary: Send codewords to an end user
+      description: request distribution of code words to be sent to a user. Upon receiving
+        a request on this end-point, the RA should distribute the provided code through
+        the channel indicated, or return an error-code.
+      operationId: selfServiceSendCodeWords
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        description: Activation codes and how to distribute
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendCodeWordsRequestBodyDTO'
         required: true
       responses:
         200:
@@ -139,175 +308,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /notify_user_of_activation:
-    post:
-      tags:
-      - Activation without Code Device
-      summary: Tell end user that BankID App is activated
-      description: Request notification of the end user that his BankID App instance
-        is activated
-      operationId: notifyUserOfActivation
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        description: Activation code metadata
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NotifyUserOfActivationRequestBodyDTO'
-        required: true
-      responses:
-        200:
-          description: If all ok, no data is returned
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotifyUserOfActivationErrorResponseDTO'
-  /selfservice/send_code_words:
-    post:
-      tags:
-      - Activation without Code Device - Self Service
-      summary: Send codewords to an end user
-      description: request distribution of code words to be sent to a user. Upon receiving
-        a request on this end-point, the RA should distribute the provided code through
-        the channel indicated, or return an error-code.
-      operationId: selfServiceSendCodeWords
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        description: Activation codes and how to distribute
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SendCodeWordsRequestBodyDTO'
-        required: true
-      responses:
-        200:
-          description: If all ok, no data is returned
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /selfservice/check_user:
-    post:
-      tags:
-      - Activation without Code Device - Self Service
-      summary: Check two-channel options for end user
-      description: <p>Endpoint to check if a specific user is eligible from single
-        originator for self-service activation.</p><p>The RA should check if the provided
-        phone number is registered for the user, but return the other information
-        regardless.
-      operationId: selfServiceCheckUser
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        description: Activation code and how to distribute
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelfServiceCheckUserRequestBodyDTO'
-        required: true
-      responses:
-        200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SelfServiceCheckUserResponseDTO'
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
   /add:
     post:
       tags:
@@ -356,62 +356,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AddBappResponseDTO'
-        400:
-          description: In case of error
-        500:
-          description: In case of error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleErrorResponseDTO'
-  /remove:
-    post:
-      tags:
-      - OTP administration
-      summary: Removes BankID App from an end user
-      description: Removes BankID App as an end user's OTP mechanism for at least
-        one of his BankIDs in a given bank
-      operationId: removeBappOtp
-      parameters:
-      - name: Signature
-        in: header
-        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
-          - Signing HTTP Messages</a>.
-        required: true
-        schema:
-          type: string
-        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
-          date digest",signature="o7zK892...."
-      - name: Date
-        in: header
-        description: 'The date element, required format is the format named ''preferred''
-          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
-          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
-          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
-        required: true
-        schema:
-          type: string
-        example: Mon, 16 Sep 2019 12:12:21 GMT
-      - name: Digest
-        in: header
-        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
-          in Java returns an object which is not thread safe</p>
-        required: true
-        schema:
-          type: string
-        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationBodyDTO'
-      responses:
-        200:
-          description: If status returned is valid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteBappResponseDTO'
         400:
           description: In case of error
         500:
@@ -476,6 +420,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponseDTO'
+  /remove:
+    post:
+      tags:
+      - OTP administration
+      summary: Removes BankID App from an end user
+      description: Removes BankID App as an end user's OTP mechanism for at least
+        one of his BankIDs in a given bank
+      operationId: removeBappOtp
+      parameters:
+      - name: Signature
+        in: header
+        description: The Signature element, as described in <a href="https://tools.ietf.org/html/draft-cavage-http-signatures-12">Internet-Draft
+          - Signing HTTP Messages</a>.
+        required: true
+        schema:
+          type: string
+        example: keyId="fa998090",algorithm="rsa-sha256",headers="(request-target)
+          date digest",signature="o7zK892...."
+      - name: Date
+        in: header
+        description: 'The date element, required format is the format named ''preferred''
+          specified in <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">RFC
+          7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>.<p><b>Implementation
+          tips:</b> Format in Java is ''EEE, dd MMM yyyy HH:mm:ss zzz'', locale english.</p>'
+        required: true
+        schema:
+          type: string
+        example: Mon, 16 Sep 2019 12:12:21 GMT
+      - name: Digest
+        in: header
+        description: SHA-256 hash of body<p><b>Implementation tips:</b>MessageDigest.getIinstance("SHA-256")
+          in Java returns an object which is not thread safe</p>
+        required: true
+        schema:
+          type: string
+        example: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationBodyDTO'
+      responses:
+        200:
+          description: If status returned is valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteBappResponseDTO'
+        400:
+          description: In case of error
+        500:
+          description: In case of error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponseDTO'
   /healthcheck:
     get:
       tags:
@@ -490,98 +490,6 @@ paths:
           description: RA is not healthy
 components:
   schemas:
-    SimpleErrorResponseDTO:
-      type: object
-      properties:
-        error:
-          type: string
-      description: Result when there is only an error code in return
-    SendVerificationCodeRequestBodyDTO:
-      type: object
-      properties:
-        client_name:
-          type: string
-          description: Name of client sending the request
-          example: vipps-bapp-client
-        request_id:
-          type: string
-          description: A unique identifier pr. request, used for log correlation
-          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
-        originator_id:
-          type: string
-          description: Originator/bank-number for end user's bankID, valid BankID
-            ODS number
-          example: "9980"
-        nnin:
-          type: string
-          description: End user's Norwegian national identification number, string
-            of 11 digits
-          example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging, will
-            be the same for both codes
-          format: uuid
-        msisdn_reference_id:
-          type: string
-          description: The alias for the msisdn previously provided in a response
-            from check-user
-        locale:
-          type: string
-          description: Locale of initiating app, either "no" for Norwegian and Norwegian
-            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
-            nuisance)</h5>
-          example: en
-          enum:
-          - no
-          - en
-        verification_code:
-          type: string
-          description: Four digit code
-        exp:
-          type: integer
-          description: Time when code expire, ms since epoch, UTC
-          format: int64
-      description: Request body content for asking an RA to send verification code
-        to end user
-    PasswordQuarantineResponseDTO:
-      type: object
-      properties:
-        pw_reset_timestamp:
-          type: integer
-          description: Time when user's password was last reset, ms since epoch, UTC
-          format: int64
-      description: Response when quarantining an end user password
-    PasswordQuarantineRequestBodyDTO:
-      type: object
-      properties:
-        client_name:
-          type: string
-          description: Name of client sending the request
-          example: vipps-bapp-client
-        request_id:
-          type: string
-          description: A unique identifier pr. request, used for log correlation
-          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
-        originator_id:
-          type: string
-          description: Originator/bank-number for end user's bankID, valid BankID
-            ODS number
-          example: "9980"
-        nnin:
-          type: string
-          description: End user's Norwegian national identification number, string
-            of 11 digits
-          example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging
-          format: uuid
-        quarantine_until:
-          type: integer
-          description: Time when quarantine expire, ms since epoch, UTC
-          format: int64
-      description: Request body content for quarantining the user password
     NotifyUserOfActivationErrorResponseDTO:
       type: object
       properties:
@@ -691,54 +599,6 @@ components:
             method all the way back to the issuing RA.
           example: 9980@1234-2f44-123456-12
       description: Details of one distribution method used during activation.
-    SendCodeWordsRequestBodyDTO:
-      type: object
-      properties:
-        client_name:
-          type: string
-          description: Name of client sending the request
-          example: vipps-bapp-client
-        request_id:
-          type: string
-          description: A unique identifier pr. request, used for log correlation
-          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
-        originator_id:
-          type: string
-          description: Originator/bank-number for end user's bankID, valid BankID
-            ODS number
-          example: "9980"
-        nnin:
-          type: string
-          description: End user's Norwegian national identification number, string
-            of 11 digits
-          example: "11111111016"
-        activation_id:
-          type: string
-          description: The id of this activation attempt, used for for logging, will
-            be the same for both codes
-          format: uuid
-        distribution_method:
-          type: string
-          description: One of the method identifiers returned from selfservice/check_user
-            call
-        locale:
-          type: string
-          description: Locale of initiating app, either "no" for Norwegian and Norwegian
-            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
-            nuisance)</h5>
-          example: en
-          enum:
-          - no
-          - en
-        code_words:
-          type: string
-          description: The two code words to distribute
-        exp:
-          type: integer
-          description: Time when code expire, ms since epoch, UTC
-          format: int64
-      description: Request body content for asking an RA to send code words to an
-        end user
     DistributionMethodDTO:
       type: object
       properties:
@@ -819,6 +679,12 @@ components:
           - BLOCKED_BY_BANK
           - BLOCKED_IN_ODS
       description: The result of querying RA about end user distribution methods
+    SimpleErrorResponseDTO:
+      type: object
+      properties:
+        error:
+          type: string
+      description: Result when there is only an error code in return
     MsisdnDTO:
       type: object
       properties:
@@ -862,6 +728,140 @@ components:
           $ref: '#/components/schemas/MsisdnDTO'
       description: Request body content for asking an RA about end user distribution
         methods
+    SendVerificationCodeRequestBodyDTO:
+      type: object
+      properties:
+        client_name:
+          type: string
+          description: Name of client sending the request
+          example: vipps-bapp-client
+        request_id:
+          type: string
+          description: A unique identifier pr. request, used for log correlation
+          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
+        originator_id:
+          type: string
+          description: Originator/bank-number for end user's bankID, valid BankID
+            ODS number
+          example: "9980"
+        nnin:
+          type: string
+          description: End user's Norwegian national identification number, string
+            of 11 digits
+          example: "11111111016"
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging, will
+            be the same for both codes
+          format: uuid
+        msisdn_reference_id:
+          type: string
+          description: The alias for the msisdn previously provided in a response
+            from check-user
+        locale:
+          type: string
+          description: Locale of initiating app, either "no" for Norwegian and Norwegian
+            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
+            nuisance)</h5>
+          example: en
+          enum:
+          - no
+          - en
+        verification_code:
+          type: string
+          description: Four digit code
+        exp:
+          type: integer
+          description: Time when code expire, ms since epoch, UTC
+          format: int64
+      description: Request body content for asking an RA to send verification code
+        to end user
+    SendCodeWordsRequestBodyDTO:
+      type: object
+      properties:
+        client_name:
+          type: string
+          description: Name of client sending the request
+          example: vipps-bapp-client
+        request_id:
+          type: string
+          description: A unique identifier pr. request, used for log correlation
+          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
+        originator_id:
+          type: string
+          description: Originator/bank-number for end user's bankID, valid BankID
+            ODS number
+          example: "9980"
+        nnin:
+          type: string
+          description: End user's Norwegian national identification number, string
+            of 11 digits
+          example: "11111111016"
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging, will
+            be the same for both codes
+          format: uuid
+        distribution_method:
+          type: string
+          description: One of the method identifiers returned from selfservice/check_user
+            call
+        locale:
+          type: string
+          description: Locale of initiating app, either "no" for Norwegian and Norwegian
+            dialects, otherwise "en"<h5>(the 'no' value is shown as 'false', openapi
+            nuisance)</h5>
+          example: en
+          enum:
+          - no
+          - en
+        code_words:
+          type: string
+          description: The two code words to distribute
+        exp:
+          type: integer
+          description: Time when code expire, ms since epoch, UTC
+          format: int64
+      description: Request body content for asking an RA to send code words to an
+        end user
+    PasswordQuarantineResponseDTO:
+      type: object
+      properties:
+        pw_reset_timestamp:
+          type: integer
+          description: Time when user's password was last reset, ms since epoch, UTC
+          format: int64
+      description: Response when quarantining an end user password
+    PasswordQuarantineRequestBodyDTO:
+      type: object
+      properties:
+        client_name:
+          type: string
+          description: Name of client sending the request
+          example: vipps-bapp-client
+        request_id:
+          type: string
+          description: A unique identifier pr. request, used for log correlation
+          example: e6dccaf0-c72f-48d9-9dc8-665e51e08e47
+        originator_id:
+          type: string
+          description: Originator/bank-number for end user's bankID, valid BankID
+            ODS number
+          example: "9980"
+        nnin:
+          type: string
+          description: End user's Norwegian national identification number, string
+            of 11 digits
+          example: "11111111016"
+        activation_id:
+          type: string
+          description: The id of this activation attempt, used for for logging
+          format: uuid
+        quarantine_until:
+          type: integer
+          description: Time when quarantine expire, ms since epoch, UTC
+          format: int64
+      description: Request body content for quarantining the user password
     AddBappResponseDTO:
       type: object
       properties:
@@ -905,21 +905,6 @@ components:
             of 11 digits
           example: "11111111016"
       description: Minimal body for authenticating and authorizing a request
-    DeleteBappResponseDTO:
-      type: object
-      properties:
-        status:
-          type: string
-          description: Status value for the delete operation <ul><li>DELETED - BAPP
-            was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled
-            for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't
-            deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>
-          enum:
-          - DELETED
-          - NOT_ENABLED
-          - BLOCKED_IN_ODS
-      description: 'The result of trying to remove BankID app from an end user''s
-        BankID '
     StatusBappResponseDTO:
       type: object
       properties:
@@ -940,3 +925,18 @@ components:
           - BLOCKED_IN_ODS
       description: The result of asking if BankID app is enabled for an end user's
         BankID
+    DeleteBappResponseDTO:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Status value for the delete operation <ul><li>DELETED - BAPP
+            was successfully deleted</li><li>NOT_ENABLED - BAPP hasn't been enabled
+            for the end user, nothing to delete.</li><li>BLOCKED_IN_ODS - BAPP wasn't
+            deleted, since it is present and blocked by ODS because of wrong attempts</li></ul>
+          enum:
+          - DELETED
+          - NOT_ENABLED
+          - BLOCKED_IN_ODS
+      description: 'The result of trying to remove BankID app from an end user''s
+        BankID '

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/NotifyUserOfActivationRequestBodyDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/NotifyUserOfActivationRequestBodyDTO.java
@@ -58,5 +58,5 @@ public class NotifyUserOfActivationRequestBodyDTO extends AuthenticationBodyDTO 
 
     @Schema(description = "The id of this activation attempt, used for for logging")
     public UUID activation_id;
-    public ActivationMetadataDTO activationMetadata;
+    public ActivationMetadataDTO activation_metadata;
 }

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
@@ -40,7 +40,7 @@ import static no.bankid.outgoing.ra.HttpSignatureHeaders.SIGNATURE;
                         "another Code Device at all !" +
                         "</p>" +
                         "<h6>This SPI version corresponds to the document " +
-                        "'Specification of Solutions for Activation of BankID App as HA2-elements' version v.62</h6>"
+                        "'Specification of Solutions for Activation of BankID App as HA2-elements' version v.63</h6>"
         ),
         tags = {
                 @Tag(name = RaRequirements.SERVICE_AVAILABILITY,

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/SelfServiceCheckUserResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/SelfServiceCheckUserResponseDTO.java
@@ -45,4 +45,5 @@ public class SelfServiceCheckUserResponseDTO {
     public MsisdnReferenceDTO msisdn_reference;
     @Schema(description = "List of distribution methods")
     public List<DistributionMethodDTO> distribution_methods;
+    public StatusBappResponseDTO.Result status;
 }


### PR DESCRIPTION
1. Fieldnames in DTO shall not be in camelcase, found one activationMetadata, which is now replaced
2. Bapp OTP Status for enduser is added to the check_user response

Remark that Toba should take a copy of this file and not use a direct link !

Merging these changes may therefore cause build problems in Toba.

swagger.json og swagger.yaml generes automatisk, man må sjekke om de er med på pullrequesten ?
